### PR TITLE
Improve stats page with date filter and category product details

### DIFF
--- a/app/Http/Controllers/Admin/AdminStatsController.php
+++ b/app/Http/Controllers/Admin/AdminStatsController.php
@@ -22,14 +22,18 @@ class AdminStatsController extends Controller
 
     public function index(Request $request)
     {
-        $selectedDate = $request->query('date');
-        $parsedDate = Carbon::createFromFormat('Y-m-d', (string) $selectedDate);
-        if ($parsedDate === false) {
+        $selectedDate = (string) $request->query('date', '');
+        try {
+            $parsedDate = Carbon::createFromFormat('Y-m-d', $selectedDate);
+            if ($parsedDate === false) {
+                $parsedDate = Carbon::today();
+            }
+        } catch (\Throwable $exception) {
             $parsedDate = Carbon::today();
         }
 
         $selectedDate = $parsedDate->toDateString();
-        $selectedCategoryId = (int) $request->query('category');
+        $selectedCategoryId = (string) $request->query('category', '');
         $startOfDay = $parsedDate->copy()->startOfDay()->toDateTimeString();
         $endOfDay = $parsedDate->copy()->endOfDay()->toDateTimeString();
         $historyStartDate = $parsedDate->copy()->subDays(13)->startOfDay()->toDateTimeString();
@@ -81,7 +85,7 @@ GROUP BY daynumber', [$historyStartDate, $endOfDay]);
 
         $selectedCategory = null;
         foreach ($categoriesHoy as $category) {
-            if ((int) $category->ID === $selectedCategoryId) {
+            if ((string) $category->ID === $selectedCategoryId) {
                 $selectedCategory = $category;
                 break;
             }

--- a/app/Http/Controllers/Admin/AdminStatsController.php
+++ b/app/Http/Controllers/Admin/AdminStatsController.php
@@ -11,37 +11,57 @@ namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
 use App\Traits\UnicentaPayedTrait;
+use Carbon\Carbon;
 use function compact;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 
 class AdminStatsController extends Controller
 {
     use UnicentaPayedTrait;
 
-    public function index()
+    public function index(Request $request)
     {
-        $ventaLinesHoy = DB::select("SELECT payments.PAYMENT, SUM(ticketlines.UNITS*ticketlines.PRICE*1.1) AS TOTAL
-FROM tickets, ticketlines, receipts, closedcash,payments
-WHERE ticketlines.TICKET = receipts.ID
-AND closedcash.MONEY = receipts.MONEY
-AND ticketlines.TICKET = tickets.Id
-and tickets.Id = payments.RECEIPT
-AND date(receipts.DATENEW)>= (CURDATE())
-AND time(receipts.DATENEW) >= '10:00'
-GROUP BY payments.PAYMENT");
+        $selectedDate = $request->query('date');
+        $parsedDate = Carbon::createFromFormat('Y-m-d', (string) $selectedDate);
+        if ($parsedDate === false) {
+            $parsedDate = Carbon::today();
+        }
 
-        $ventaLinesHoyNight = DB::select("SELECT payments.PAYMENT, SUM(ticketlines.UNITS*ticketlines.PRICE*1.1) AS TOTAL
+        $selectedDate = $parsedDate->toDateString();
+        $selectedCategoryId = (int) $request->query('category');
+        $startOfDay = $parsedDate->copy()->startOfDay()->toDateTimeString();
+        $endOfDay = $parsedDate->copy()->endOfDay()->toDateTimeString();
+        $historyStartDate = $parsedDate->copy()->subDays(13)->startOfDay()->toDateTimeString();
+
+        $ventaLinesHoy = DB::select(
+            "SELECT payments.PAYMENT, SUM(ticketlines.UNITS*ticketlines.PRICE*1.1) AS TOTAL
 FROM tickets, ticketlines, receipts, closedcash,payments
 WHERE ticketlines.TICKET = receipts.ID
 AND closedcash.MONEY = receipts.MONEY
 AND ticketlines.TICKET = tickets.Id
 and tickets.Id = payments.RECEIPT
-AND date(receipts.DATENEW)>= (CURDATE())
-AND time(receipts.DATENEW) <= '10:00'
-GROUP BY payments.PAYMENT");
+AND receipts.DATENEW BETWEEN ? AND ?
+AND time(receipts.DATENEW) >= '10:00:00'
+GROUP BY payments.PAYMENT",
+            [$startOfDay, $endOfDay]
+        );
+
+        $ventaLinesHoyNight = DB::select(
+            "SELECT payments.PAYMENT, SUM(ticketlines.UNITS*ticketlines.PRICE*1.1) AS TOTAL
+FROM tickets, ticketlines, receipts, closedcash,payments
+WHERE ticketlines.TICKET = receipts.ID
+AND closedcash.MONEY = receipts.MONEY
+AND ticketlines.TICKET = tickets.Id
+and tickets.Id = payments.RECEIPT
+AND receipts.DATENEW BETWEEN ? AND ?
+AND time(receipts.DATENEW) < '10:00:00'
+GROUP BY payments.PAYMENT",
+            [$startOfDay, $endOfDay]
+        );
         $cajaActual = $this->getClosedCash();
 
-        $categoriesHoy = DB::select('SELECT  categories.name as NAME, COUNT(categories.name) AS CHECKS, SUM(ticketlines.UNITS*ticketlines.PRICE*1.1) AS TOTAL
+        $categoriesHoy = DB::select('SELECT categories.ID AS ID, categories.name as NAME, COUNT(categories.name) AS CHECKS, SUM(ticketlines.UNITS*ticketlines.PRICE*1.1) AS TOTAL
 FROM tickets, ticketlines, receipts,
  closedcash,products,categories
 WHERE ticketlines.TICKET = receipts.ID
@@ -49,15 +69,38 @@ AND closedcash.MONEY = receipts.MONEY
 AND ticketlines.TICKET = tickets.Id
 AND ticketlines.PRODUCT = products.ID
 AND products.CATEGORY = categories.ID
-AND date(receipts.DATENEW) >= (curdate())
-GROUP BY NAME');
+AND receipts.DATENEW BETWEEN ? AND ?
+GROUP BY categories.ID, NAME', [$startOfDay, $endOfDay]);
 
         $ventaPorDias = DB::select('SELECT date(receipts.Datenew) as daynumber, COUNT(DISTINCT(receipts.ID)) AS CHECKS, SUM(ticketlines.UNITS*ticketlines.PRiCE*1.1) AS TOTAL
  FROM tickets, ticketlines, receipts, closedcash WHERE ticketlines.TICKET = receipts.ID
 AND closedcash.MONEY = receipts.MONEY
 AND ticketlines.TICKET = tickets.Id
-AND receipts.DATENEW >= CURDATE()-13
-GROUP BY daynumber');
+AND receipts.DATENEW BETWEEN ? AND ?
+GROUP BY daynumber', [$historyStartDate, $endOfDay]);
+
+        $selectedCategory = null;
+        foreach ($categoriesHoy as $category) {
+            if ((int) $category->ID === $selectedCategoryId) {
+                $selectedCategory = $category;
+                break;
+            }
+        }
+
+        $categoryProductDetails = [];
+        if ($selectedCategory !== null) {
+            $categoryProductDetails = DB::select('SELECT products.NAME as NAME, SUM(ticketlines.UNITS) AS UNITS, SUM(ticketlines.UNITS*ticketlines.PRICE*1.1) AS TOTAL
+FROM tickets, ticketlines, receipts, closedcash, products, categories
+WHERE ticketlines.TICKET = receipts.ID
+AND closedcash.MONEY = receipts.MONEY
+AND ticketlines.TICKET = tickets.Id
+AND ticketlines.PRODUCT = products.ID
+AND products.CATEGORY = categories.ID
+AND categories.ID = ?
+AND receipts.DATENEW BETWEEN ? AND ?
+GROUP BY products.ID, products.NAME
+ORDER BY TOTAL DESC', [$selectedCategoryId, $startOfDay, $endOfDay]);
+        }
 
 
         $totalDay = 0;
@@ -73,7 +116,19 @@ GROUP BY daynumber');
 
         }
 
-        return view('admin.stats.index', compact(['ventaLinesHoy', 'ventaLinesHoyNight', 'cajaActual','categoriesHoy', 'ventaPorDias', 'totalDay','totalNight']));
+        return view('admin.stats.index', compact([
+            'ventaLinesHoy',
+            'ventaLinesHoyNight',
+            'cajaActual',
+            'categoriesHoy',
+            'ventaPorDias',
+            'totalDay',
+            'totalNight',
+            'selectedDate',
+            'selectedCategoryId',
+            'selectedCategory',
+            'categoryProductDetails',
+        ]));
     }
 
 

--- a/resources/views/admin/stats/index.blade.php
+++ b/resources/views/admin/stats/index.blade.php
@@ -17,6 +17,27 @@
 
                         <br>
 
+                        <form method="GET" action="/stats" class="mb-3">
+                            <div class="form-row align-items-end">
+                                <div class="col-sm-6">
+                                    <label for="stats-date"><b>Fecha para stats</b></label>
+                                    <input
+                                        id="stats-date"
+                                        type="date"
+                                        name="date"
+                                        class="form-control"
+                                        value="{{ $selectedDate }}"
+                                    >
+                                </div>
+                                @if($selectedCategoryId)
+                                    <input type="hidden" name="category" value="{{ $selectedCategoryId }}">
+                                @endif
+                                <div class="col-sm-3 mt-2 mt-sm-0">
+                                    <button type="submit" class="btn btn-primary btn-block">Filtrar</button>
+                                </div>
+                            </div>
+                        </form>
+
                         <div>&nbsp;</div>
                         <table class="table table-sm">
 
@@ -27,14 +48,14 @@
                             @endforeach
                             <tr><td colspan="2" class="">&nbsp;</td></tr>
 
-                            <tr class="bg-light"><td colspan="2" class="text-center"><h4>Venta de Hoy por el dia</h4></td></tr>
+                            <tr class="bg-light"><td colspan="2" class="text-center"><h4>Venta del día ({{ $selectedDate }}) por el día</h4></td></tr>
 
                             @foreach($ventaLinesHoy as $ventaLine)
                                 <tr><td>{{$ventaLine->PAYMENT}}</td><td>@money($ventaLine->TOTAL)</td></tr>
                             @endforeach
                                 <tr><td><b>TOTAL</b></td><td><b>@money($totalDay)</b></td></tr>
                             <tr><td colspan="2" class="">&nbsp;</td></tr>
-                            <tr class="bg-light"><td colspan="2" class="text-center"><h4>Venta de Hoy por la noche</h4></td></tr>
+                            <tr class="bg-light"><td colspan="2" class="text-center"><h4>Venta del día ({{ $selectedDate }}) por la noche</h4></td></tr>
 
                             @foreach($ventaLinesHoyNight as $ventaLine)
                                 <tr><td>{{$ventaLine->PAYMENT}}</td><td>@money($ventaLine->TOTAL)</td></tr>
@@ -42,12 +63,31 @@
                             <tr><td><b>TOTAL</b></td><td><b>@money($totalNight)</b></td></tr>
                             <tr><td colspan="2" class="">&nbsp;</td></tr>
 
-                            <tr class="bg-light"><td colspan="2" class="text-center"><h4>Venta por Categoria</h4></td></tr>
+                            <tr class="bg-light"><td colspan="2" class="text-center"><h4>Venta por categoria ({{ $selectedDate }})</h4></td></tr>
                             @foreach($categoriesHoy as $categorie)
-                                <tr><td>{{$categorie->NAME}}</td><td>@money($categorie->TOTAL)</td></tr>
+                                <tr>
+                                    <td>
+                                        <a href="/stats?date={{ $selectedDate }}&category={{ $categorie->ID }}">
+                                            {{$categorie->NAME}}
+                                        </a>
+                                    </td>
+                                    <td>@money($categorie->TOTAL)</td>
+                                </tr>
 
                                 @endforeach
                             <tr><td colspan="2" class="">&nbsp;</td></tr>
+                            @if($selectedCategory)
+                                <tr class="bg-light"><td colspan="2" class="text-center"><h4>Detalle de productos: {{ $selectedCategory->NAME }} ({{ $selectedDate }})</h4></td></tr>
+                                @forelse($categoryProductDetails as $productDetail)
+                                    <tr>
+                                        <td>{{ $productDetail->NAME }} <small class="text-muted">(x{{ number_format($productDetail->UNITS, 2) }})</small></td>
+                                        <td>@money($productDetail->TOTAL)</td>
+                                    </tr>
+                                @empty
+                                    <tr><td colspan="2" class="text-center text-muted">No hay productos para esta categoria en la fecha seleccionada.</td></tr>
+                                @endforelse
+                                <tr><td colspan="2" class="">&nbsp;</td></tr>
+                            @endif
                             <tr class="bg-light"> <td colspan="2" class="text-center"><h4>Venta por dia</h4></td></tr>
                             @foreach($ventaPorDias as $ventaPorDia)
                                 <tr><td>{{Carbon\Carbon::parse($ventaPorDia->daynumber)->format('l')}}&nbsp;- &nbsp;{{$ventaPorDia->daynumber}}</td><td>@money($ventaPorDia->TOTAL)</td></tr>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a date selector on `/stats` to filter sales data by selected day
- update stats queries to use the selected date instead of only current date
- make category rows clickable and show product-level totals for the selected category on the selected date
- harden parsing so invalid `date` query values fall back to today and category ids are treated as strings

## Testing
- linted updated controller
- manually validated date filtering and category product drill-down in browser
- verified selected category details only include products from that category

## Walkthrough artifacts
[stats_date_and_category_details_final_demo.mp4](https://cursor.com/agents/bc-5eadb52c-a671-4c92-b0e1-5f73616031d6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstats_date_and_category_details_final_demo.mp4)
[Drinks details for selected date](https://cursor.com/agents/bc-5eadb52c-a671-4c92-b0e1-5f73616031d6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstats_drinks_details_final.webp)
[Food details for selected date](https://cursor.com/agents/bc-5eadb52c-a671-4c92-b0e1-5f73616031d6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstats_food_details_final.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5eadb52c-a671-4c92-b0e1-5f73616031d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5eadb52c-a671-4c92-b0e1-5f73616031d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

