### PR TITLE
Redesign /checkout/pay (Pago) — hero amount, table badge, cleaner layout

### DIFF
--- a/resources/views/order/pay.blade.php
+++ b/resources/views/order/pay.blade.php
@@ -7,82 +7,102 @@
 @section('content')
 @php
     $ticketId = Session::get('ticketID');
+    $tableNumber = Session::get('tableNumber');
+    $isPickup = (bool) Session::get('isPickup');
+    $isTableMesa = $tableNumber && (int) $tableNumber < 100;
+
+    $base = (float) $newLinesPrice;
+    $iva = $base * 0.1;
+    $amountDue = round($base + $iva, 2);
+    $hasPreviousLines = $totalBasketPrice > $newLinesPrice;
+    $previousBase = (float) $totalBasketPrice - $base;
+    $previousIva = $previousBase * 0.1;
+    $previousTotal = $previousBase + $previousIva;
+    $grandTotal = round((float) $totalBasketPrice * 1.1, 2);
+
     $onApproveUrl = (config('customoptions.clean_table_after_order') || (is_numeric($ticketId) && (int) $ticketId < 100))
         ? url('/checkout/printOrderOnline/'.$ticketId)
         : url('/checkout/printOrderPagado/'.$ticketId);
     $payPageConfig = [
-        'amount' => round((float) $newLinesPrice * 1.1, 2),
+        'amount' => $amountDue,
         'paypalClientId' => config('paypal.client_id'),
         'onApproveUrl' => $onApproveUrl,
     ];
+
+    if ($isPickup) {
+        $referenceLabel = __('Pedido para recoger');
+        $referenceValue = '#' . $tableNumber;
+    } elseif ($isTableMesa) {
+        $referenceLabel = __('Mesa');
+        $referenceValue = (string) $tableNumber;
+    } else {
+        $referenceLabel = null;
+        $referenceValue = null;
+    }
 @endphp
-<div class="card-tw mx-auto max-w-3xl">
-    <div class="card-tw-header text-center"><b>{{ __('Pedido') }}</b></div>
-    <div class="card-tw-body text-center">
-                <table id="products-table" class="table ">
-                    <thead>
 
+<div class="mx-auto max-w-md space-y-4 max-sm:pb-28">
+    <header class="text-center">
+        <h1 class="text-xl font-semibold text-slate-900">{{ __('Pago') }}</h1>
+        @if ($referenceLabel)
+            <p class="mt-1 text-sm text-slate-500">
+                {{ $referenceLabel }}
+                <span class="ml-1 inline-flex items-center rounded-full bg-slate-900 px-2.5 py-0.5 text-xs font-semibold text-white tabular-nums">{{ $referenceValue }}</span>
+            </p>
+        @endif
+    </header>
 
-                    </thead>
-                    <tbody>
+    <section class="card-tw" aria-labelledby="pay-amount-label">
+        <div class="flex flex-col items-center gap-1 px-6 py-6 text-center">
+            <span id="pay-amount-label" class="text-xs font-medium uppercase tracking-wide text-slate-500">
+                {{ __('A pagar') }}
+            </span>
+            <span class="text-4xl font-bold tabular-nums text-slate-900" data-pay-amount>
+                @money($amountDue)
+            </span>
+            <dl class="mt-2 grid w-full max-w-xs grid-cols-2 gap-x-4 gap-y-0.5 text-xs text-slate-500">
+                <dt class="text-left">{{ __('Base') }}</dt>
+                <dd class="text-right tabular-nums">@money($base)</dd>
+                <dt class="text-left">{{ __('IVA') }} (10%)</dt>
+                <dd class="text-right tabular-nums">@money($iva)</dd>
+            </dl>
+        </div>
 
-                        <tr>
-                            <td colspan="5">&nbsp;</td>
-                        </tr>
-                        <tr>
-                            <td colspan="">&nbsp;</td>
-                            <td colspan="">Base</td>
-                            <td colspan="">IVA</td>
-                            <td colspan=""></td>
-                            <td colspan="">Total</td>
-                        </tr>
-                        <tr>
-                            <td colspan="">TOTAL</td>
-                            <td>@money($totalBasketPrice)</td>
-                            <td>@money($totalBasketPrice*0.1)</td>
-
-                            <td></td>
-                            <td>@money($totalBasketPrice*1.1)</td>
-                        </tr>
-                        <tr>
-                            <td colspan=""><b>A Pedir</b></td>
-                            <td>@money($newLinesPrice)</td>
-                            <td>@money($newLinesPrice*0.1)</td>
-
-                            <td></td>
-                            <td>&nbsp;<b>@money($newLinesPrice*1.1)</b></td>
-
-
-                        </tr>
-
-                        <tr>
-                            <td colspan="5">&nbsp;</td>
-                        </tr>
-                        {{--
-                        Si tiene numero de mesa puede ser:
-                        1. de prepago
-                        2. a cuenta
-                        --}}
-
-
-                    </tbody>
-                </table>
-
-
-                <div class="mx-auto max-w-sm space-y-3 pt-2 text-left">
-                    <div id="applepay-container" class="empty:hidden"></div>
-                    <div id="googlepay-container" class="empty:hidden"></div>
-                    <details class="group rounded-lg border border-slate-200 bg-white">
-                        <summary class="cursor-pointer select-none px-4 py-3 text-sm font-medium text-slate-700 marker:hidden">
-                            {{ __('Otras formas de pagar') }}
-                        </summary>
-                        <div class="px-4 pb-4 pt-2">
-                            <div id="paypal-button-container"></div>
-                        </div>
-                    </details>
+        @if ($hasPreviousLines)
+            <div class="border-t border-slate-100 bg-slate-50 px-6 py-3 text-xs text-slate-600">
+                <div class="flex items-baseline justify-between">
+                    <span>{{ __('Ya en su cuenta') }}</span>
+                    <span class="tabular-nums">@money($previousTotal)</span>
                 </div>
+                <div class="mt-1 flex items-baseline justify-between font-semibold text-slate-800">
+                    <span>{{ __('Total acumulado') }}</span>
+                    <span class="tabular-nums">@money($grandTotal)</span>
+                </div>
+            </div>
+        @endif
+    </section>
 
-    </div>
+    <section class="space-y-3" aria-label="{{ __('Métodos de pago') }}">
+        <div id="applepay-container" class="empty:hidden"></div>
+        <div id="googlepay-container" class="empty:hidden"></div>
+        <details class="group rounded-lg border border-slate-200 bg-white">
+            <summary class="cursor-pointer select-none px-4 py-3 text-sm font-medium text-slate-700 marker:hidden">
+                <span class="inline-flex items-center gap-2">
+                    <svg class="h-4 w-4 text-slate-400 transition group-open:rotate-90" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                        <path fill-rule="evenodd" d="M7.21 14.77a.75.75 0 0 1 .02-1.06L11.168 10 7.23 6.29a.75.75 0 1 1 1.04-1.08l4.5 4.25a.75.75 0 0 1 0 1.08l-4.5 4.25a.75.75 0 0 1-1.06-.02Z" clip-rule="evenodd" />
+                    </svg>
+                    {{ __('Otras formas de pagar') }}
+                </span>
+            </summary>
+            <div class="px-4 pb-4 pt-2">
+                <div id="paypal-button-container"></div>
+            </div>
+        </details>
+    </section>
+
+    <p class="text-center text-xs text-slate-400">
+        {{ __('Pago seguro. No se guardan los datos de la tarjeta.') }}
+    </p>
 </div>
 @endsection
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Redesign of the customer-facing payment page (`/checkout/pay`, view `resources/views/order/pay.blade.php`).

The previous markup was a Bootstrap-style `<table>` (with an empty `<thead>` and `&nbsp;` spacer rows) wedged into the Tailwind `layouts.shop` shell. The amount the customer is about to pay was buried in a row labelled "A Pedir" inside a 3-column "Base / IVA / Total" grid — same screen real-estate as the un-actionable totals.

## What changes

View-only — controller (`BasketController::pay()`), routes, and the `pay-page-config` JSON contract consumed by the Apple Pay / Google Pay / PayPal client JS are unchanged.

- **Hero amount.** `A pagar` rendered as a 4xl `tabular-nums` figure, centred in a `card-tw`. This is the number the customer actually needs to see.
- **Reference badge.** Under the page title, the table number (mesa) or pickup number is shown as a pill (`#42` for pickup, `42` for table). Hidden when the session has neither.
- **Base / IVA breakdown** moved to a small `<dl>` directly under the hero amount, in muted text.
- **Previously-ordered lines** ("Ya en su cuenta" + "Total acumulado") only render when `$totalBasketPrice > $newLinesPrice`. On a fresh ticket the section is hidden, removing the previously-confusing duplicate "TOTAL" / "A Pedir" rows that always showed identical numbers.
- **Page title & h1** changed from "Pedido" to "Pago" — this is the payment screen, not the order screen.
- **Pay methods column widened** to `max-w-md` so the Google Pay / Apple Pay buttons line up with the amount card above them (they were `max-w-sm` inside a `max-w-3xl` card before, visually adrift).
- **Reassurance footer.** Small "Pago seguro. No se guardan los datos de la tarjeta." line under the methods.
- **Mobile bottom padding.** `max-sm:pb-28` so the page doesn't get covered by `partials.shop.bottom-bar` on phones.

## What stays the same

- `resources/views/order/checkout.blade.php` is unchanged. (The pre-pay screen at `/checkout/`, which is a separate view, isn't touched here — that's a separate redesign if you want it.)
- All ids and DOM hooks the JS depends on are preserved: `#applepay-container`, `#googlepay-container`, `#paypal-button-container`, `#pay-page-config`.
- `BasketController::pay()` still passes `$totalBasketPrice`, `$newLinesPrice`, `$tablenames`. (`$tablenames` was unused by the view before this PR and remains unused.)
- The `onApproveUrl` PHP logic that picks `/checkout/printOrderOnline/` vs `/checkout/printOrderPagado/` is identical to the previous file.

## Testing

- ✅ `php artisan view:cache` — Blade compiles cleanly across the app, including the redesigned view.
- Functional walkthrough on `https://test.playaalta.com` performed via `/order/table/35` to seed a session with `tableNumber=35`, then `/checkout/pay`. Before/after artifacts are attached in the comments.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-73a2bb5c-ea20-4296-a514-1abee2afe2c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-73a2bb5c-ea20-4296-a514-1abee2afe2c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

