### PR TITLE
Product edit: refactor — FormRequests, Policy, VAT in model, allergen component (PR 4/4)

### DIFF
--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -2,109 +2,73 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\AddOnProductRequest;
+use App\Http\Requests\RemoveAddOnProductRequest;
+use App\Http\Requests\StoreProductRequest;
+use App\Http\Requests\ToggleAllergenRequest;
+use App\Http\Requests\UpdateProductRequest;
+use App\Models\ProductAdOn;
 use App\Models\ProductDetail;
 use App\Models\UnicentaModels\Category;
-use App\Models\ProductAdOn;
-use App\Traits\ProductTrait;
 use App\Models\UnicentaModels\Product;
 use App\Models\UnicentaModels\Products_Cat;
+use App\Traits\ProductTrait;
 use Illuminate\Http\Request;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Facades\Redirect;
-use function str_replace;
-use function view;
 
 class ProductController extends Controller
 {
     use ProductTrait;
-    /**
-     * Display a listing of the resource.
-     *
-     * @return \Illuminate\Http\Response
-     */
-    public function index($category=null)
+
+    public function index($category = null)
     {
-        //
-        if(empty($category)) {
+        if (empty($category)) {
             $products = Product::paginate(50);
-        }else{
-            $products= $this->getCategoryProducts($category);
-    }
+        } else {
+            $products = $this->getCategoryProducts($category);
+        }
+
         $categories = Category::orderByRaw('CONVERT(catorder, SIGNED)')->get();
 
-        return view('admin.products.index',compact('categories','products'))
+        return view('admin.products.index', compact('categories', 'products'))
             ->with('i', (request()->input('page', 1) - 1) * 5);
     }
 
-    /**
-     * Show the form for creating a new resource.
-     *
-     * @return \Illuminate\Http\Response
-     */
     public function create()
     {
-        //
+        $this->authorize('create', Product::class);
+
         $categories = Category::all();
-        return view('admin.products.create',compact('categories'));
+        return view('admin.products.create', compact('categories'));
     }
 
-    /**
-     * Store a newly created resource in storage.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\Http\Response
-     */
-    public function store(Request $request)
+    public function store(StoreProductRequest $request)
     {
-        $validated = $request->validate([
-            'code'      => 'required|string|max:255',
-            'reference' => 'required|string|max:255',
-            'category'  => 'required|string|max:255',
-            'pricebuy'  => 'required',
-            'pricesell' => 'required',
-            'name'      => 'required|string|max:255',
-            'taxcat'    => 'nullable|string|max:255',
-            'printto'   => 'nullable|string|max:255',
-        ]);
+        $attrs = $request->productAttributes();
 
-        Product::create(Arr::only($validated, [
-            'name', 'pricebuy', 'pricesell', 'code', 'reference', 'taxcat', 'category', 'printto',
-        ]));
+        $product = Product::create($attrs);
 
-        $createdProduct = Product::where('code', $validated['code'])->first();
+        // The form posts a gross (with-IVA) sell price; convert it back to net
+        // so it matches what the rest of the application stores.
+        $product->price_sell_gross = $request->input('pricesell');
+        $product->save();
 
-        $pricesell = str_replace(',', '.', $validated['pricesell']);
-        $createdProduct->pricesell = $pricesell / 1.1;
-        $createdProduct->save();
-        $product_id = $createdProduct->id;
-        $this->addOrDeleteFromCatalog($product_id);
+        $this->addOrDeleteFromCatalog($product->id);
 
-        return redirect()->route('products.edit', $product_id)
+        return redirect()->route('products.edit', $product->id)
             ->with('success', 'Product created successfully.');
     }
 
-    /**
-     * Display the specified resource.
-     *
-     * @param  int  $id
-     * @return \Illuminate\Http\Response
-     */
     public function show($product)
     {
-        //
-        return view('products.show',compact('product'));
+        return view('products.show', compact('product'));
     }
 
-    /**
-     * Show the form for editing the specified resource.
-     *
-     * @param  int  $id
-     * @return \Illuminate\Http\Response
-     */
     public function edit($id)
     {
         $product = Product::with('product_detail')->findOrFail($id);
+        $this->authorize('update', $product);
+
         $hasImage = ! empty($product->image);
 
         $addonIds = ProductAdOn::where('product_id', $product->id)->pluck('adon_product_id');
@@ -128,58 +92,36 @@ class ProductController extends Controller
         ));
     }
 
-    /**
-     * Update the specified resource in storage.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  int  $id
-     * @return \Illuminate\Http\Response
-     */
-    public function update(Request $request, $id)
+    public function update(UpdateProductRequest $request, $id)
     {
-        $validated = $request->validate([
-            'code'       => 'required|string|max:255',
-            'taxcat'     => 'required|string|max:255',
-            'reference'  => 'required|string|max:255',
-            'category'   => 'required|string|max:255',
-            'pricebuy'   => 'required',
-            'pricesell'  => 'required',
-            'name'       => 'required|string|max:255',
-            'printto'    => 'nullable|string|max:255',
-            'stockunits' => 'nullable|string|max:255',
-        ]);
-
         Log::debug('product update id:' . $id);
 
         $product = Product::findOrFail($id);
+        $this->authorize('update', $product);
 
-        $product->fill(Arr::only($validated, [
-            'name', 'code', 'reference', 'category', 'taxcat', 'pricebuy',
-        ]));
+        $product->fill($request->productAttributes());
+        $product->printto = trim((string) $request->input('printto', $product->printto));
+        $product->price_sell_gross = $request->input('pricesell');
 
-        $product->printto = isset($validated['printto']) ? trim($validated['printto']) : $product->printto;
-
-        $pricesell = str_replace(',', '.', $validated['pricesell']);
-        $product->pricesell = $pricesell / 1.1;
-
-        if (array_key_exists('stockunits', $validated) && $validated['stockunits'] !== null) {
-            $product->stockunits = str_replace(',', '.', $validated['stockunits']);
+        $stockunits = $request->input('stockunits');
+        if ($stockunits !== null && $stockunits !== '') {
+            $product->stockunits = str_replace(',', '.', $stockunits);
         }
 
         $product->save();
-        $this->updateProductDetail($request, $id);
+        $this->updateProductDetail($request->productDetailAttributes(), $product->id);
 
-        return $this->safeRedirectBack(
+        return $this->safeRedirect(
             $request->input('redirects_to'),
             route('products.edit', $product->id)
         )->with('success', 'Product updated successfully');
     }
 
     /**
-     * Validate the supplied "redirects_to" URL is a same-host path before
-     * redirecting. Falls back to $fallback otherwise. Prevents open-redirects.
+     * Validate the supplied URL is a same-host path before redirecting.
+     * Falls back to $fallback otherwise. Prevents open-redirects.
      */
-    private function safeRedirectBack(?string $candidate, string $fallback)
+    private function safeRedirect(?string $candidate, string $fallback)
     {
         if (empty($candidate)) {
             return redirect()->to($fallback);
@@ -195,45 +137,29 @@ class ProductController extends Controller
         return redirect()->to($fallback);
     }
 
-    private function updateProductDetail(Request $request,$id){
-
-        $productDetail = ProductDetail::where('product_id',$id)->first();
-        if(empty($productDetail)){
-            $productDetail = new ProductDetail();
-            $productDetail->product_id = $id;
-        }
-        $productDetail->description = $request->description;
-        $productDetail->lang1=$request->lang1;
-        $productDetail->lang2=$request->lang2;
-        $productDetail->lang3=$request->lang3;
-        $productDetail->save();
-
-
-
+    private function updateProductDetail(array $attrs, $productId): void
+    {
+        $detail = ProductDetail::firstOrNew(['product_id' => $productId]);
+        $detail->fill($attrs);
+        $detail->save();
     }
 
-    /**
-     * Remove the specified resource from storage.
-     *
-     * @param  int  $id
-     * @return \Illuminate\Http\Response
-     */
     public function destroy($id)
     {
-        //
-        $product=Product::findOrFail($id);
+        $product = Product::findOrFail($id);
+        $this->authorize('delete', $product);
+
         $product->product_cat()->delete();
         $product->delete();
 
         return redirect()->route('products.index')
-            ->with('success','Product deleted successfully');
+            ->with('success', 'Product deleted successfully');
     }
 
     public function editImage($id)
     {
-
         $product = Product::find($id);
-        if (!empty($product->image)) {
+        if (! empty($product->image)) {
             $product->image = base64_encode($product->image);
         }
 
@@ -244,46 +170,39 @@ class ProductController extends Controller
     {
         $image_file = $request->image;
         $product = Product::find($request->productID);
-        list($type, $image_file) = explode(';', $image_file);
+        list(, $image_file) = explode(';', $image_file);
         list(, $image_file) = explode(',', $image_file);
         $image_file = base64_decode($image_file);
         $product->image = $image_file;
         $product->save();
         return response()->json(['status' => true]);
     }
-    public function toggleCatalog(Request $request){
+
+    public function toggleCatalog(Request $request)
+    {
         $product_id = $request->product_id;
-        Log::debug('product_id:'.$product_id);
+        Log::debug('product_id:' . $product_id);
 
         $this->addOrDeleteFromCatalog($product_id);
 
-        return "SUCCES";
-
+        return 'SUCCES';
     }
 
-    public function addOnProductAdd(Request $request){
-        $validated = $request->validate([
-            'product_id'      => 'required|string|exists:products,id',
-            'adon_product_id' => 'required|string|exists:products,id',
-            'price'           => 'nullable',
+    public function addOnProductAdd(AddOnProductRequest $request)
+    {
+        ProductAdOn::create([
+            'product_id'      => $request->input('product_id'),
+            'adon_product_id' => $request->input('adon_product_id'),
+            'price'           => $request->priceAsFloat(),
         ]);
-
-        if (isset($validated['price'])) {
-            $validated['price'] = (float) str_replace(',', '.', (string) $validated['price']);
-        }
-
-        ProductAdOn::create($validated);
 
         return response()->json(['status' => true]);
     }
-    public function removeAddOnProductAdd(Request $request){
-        $validated = $request->validate([
-            'product_id'      => 'required|string|exists:products,id',
-            'adon_product_id' => 'required|string|exists:products,id',
-        ]);
 
-        $row = ProductAdOn::where('product_id', $validated['product_id'])
-            ->where('adon_product_id', $validated['adon_product_id'])
+    public function removeAddOnProductAdd(RemoveAddOnProductRequest $request)
+    {
+        $row = ProductAdOn::where('product_id', $request->input('product_id'))
+            ->where('adon_product_id', $request->input('adon_product_id'))
             ->first();
 
         if ($row !== null) {
@@ -293,15 +212,11 @@ class ProductController extends Controller
         return response()->json(['status' => true]);
     }
 
-    /**
-     * @param $product_id
-     */
     private function addOrDeleteFromCatalog($product_id): void
     {
         $productcat = Products_Cat::find($product_id);
         if (empty($productcat)) {
             $cat = new Products_Cat();
-
             $cat->product = $product_id;
             $cat->save();
         } else {
@@ -309,25 +224,21 @@ class ProductController extends Controller
         }
     }
 
-    public function getProductList($id){
-        return Product::select('id','name')->where('category',$id)->get();
+    public function getProductList($id)
+    {
+        return Product::select('id', 'name')->where('category', $id)->get();
     }
 
-    public function toggleAlergen(Request $request){
-        $validated = $request->validate([
-            'product_id' => 'required|string|exists:products,id',
-            'alergen_id' => ['required', 'string', \Illuminate\Validation\Rule::in(ProductDetail::ALLERGEN_KEYS)],
-        ]);
-
-        $productDetail = ProductDetail::firstOrNew(['product_id' => $validated['product_id']]);
-        $productDetail->{$validated['alergen_id']} = ! (bool) $productDetail->{$validated['alergen_id']};
+    public function toggleAlergen(ToggleAllergenRequest $request)
+    {
+        $productDetail = ProductDetail::firstOrNew(['product_id' => $request->input('product_id')]);
+        $key = $request->input('alergen_id');
+        $productDetail->{$key} = ! (bool) $productDetail->{$key};
         $productDetail->save();
 
         return response()->json([
             'status' => true,
-            'active' => (bool) $productDetail->{$validated['alergen_id']},
+            'active' => (bool) $productDetail->{$key},
         ]);
     }
-
-
 }

--- a/app/Http/Requests/AddOnProductRequest.php
+++ b/app/Http/Requests/AddOnProductRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class AddOnProductRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        $user = $this->user();
+        return $user !== null && method_exists($user, 'isManager') && $user->isManager();
+    }
+
+    public function rules(): array
+    {
+        return [
+            'product_id'      => 'required|string|exists:products,id',
+            'adon_product_id' => 'required|string|exists:products,id',
+            'price'           => 'nullable',
+        ];
+    }
+
+    public function priceAsFloat(): ?float
+    {
+        $raw = $this->input('price');
+        if ($raw === null || $raw === '') {
+            return null;
+        }
+        return (float) str_replace(',', '.', (string) $raw);
+    }
+}

--- a/app/Http/Requests/RemoveAddOnProductRequest.php
+++ b/app/Http/Requests/RemoveAddOnProductRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class RemoveAddOnProductRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        $user = $this->user();
+        return $user !== null && method_exists($user, 'isManager') && $user->isManager();
+    }
+
+    public function rules(): array
+    {
+        return [
+            'product_id'      => 'required|string|exists:products,id',
+            'adon_product_id' => 'required|string|exists:products,id',
+        ];
+    }
+}

--- a/app/Http/Requests/StoreProductRequest.php
+++ b/app/Http/Requests/StoreProductRequest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreProductRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        $user = $this->user();
+        return $user !== null && method_exists($user, 'isManager') && $user->isManager();
+    }
+
+    public function rules(): array
+    {
+        return [
+            'code'      => 'required|string|max:255',
+            'reference' => 'required|string|max:255',
+            'category'  => 'required|string|max:255',
+            'pricebuy'  => 'required',
+            'pricesell' => 'required',
+            'name'      => 'required|string|max:255',
+            'taxcat'    => 'nullable|string|max:255',
+            'printto'   => 'nullable|string|max:255',
+        ];
+    }
+
+    /**
+     * Whitelist of fields that may be assigned directly to the Product model.
+     */
+    public function productAttributes(): array
+    {
+        return $this->safe()->only([
+            'name', 'pricebuy', 'pricesell', 'code', 'reference', 'taxcat', 'category', 'printto',
+        ]);
+    }
+}

--- a/app/Http/Requests/ToggleAllergenRequest.php
+++ b/app/Http/Requests/ToggleAllergenRequest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Models\ProductDetail;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class ToggleAllergenRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        $user = $this->user();
+        return $user !== null && method_exists($user, 'isManager') && $user->isManager();
+    }
+
+    public function rules(): array
+    {
+        return [
+            'product_id' => 'required|string|exists:products,id',
+            'alergen_id' => ['required', 'string', Rule::in(ProductDetail::ALLERGEN_KEYS)],
+        ];
+    }
+}

--- a/app/Http/Requests/UpdateProductRequest.php
+++ b/app/Http/Requests/UpdateProductRequest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateProductRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        $user = $this->user();
+        return $user !== null && method_exists($user, 'isManager') && $user->isManager();
+    }
+
+    public function rules(): array
+    {
+        return [
+            'code'        => 'required|string|max:255',
+            'taxcat'      => 'required|string|max:255',
+            'reference'   => 'required|string|max:255',
+            'category'    => 'required|string|max:255',
+            'pricebuy'    => 'required',
+            'pricesell'   => 'required',
+            'name'        => 'required|string|max:255',
+            'printto'     => 'nullable|string|max:255',
+            'stockunits'  => 'nullable|string|max:255',
+            'description' => 'nullable|string',
+            'lang1'       => 'nullable|string|max:255',
+            'lang2'       => 'nullable|string|max:255',
+            'lang3'       => 'nullable|string|max:255',
+        ];
+    }
+
+    /**
+     * Whitelist of fields that may be assigned directly to the Product model.
+     * Excludes pricesell/printto/stockunits because the controller normalises
+     * them before assignment.
+     */
+    public function productAttributes(): array
+    {
+        return $this->safe()->only([
+            'name', 'code', 'reference', 'category', 'taxcat', 'pricebuy',
+        ]);
+    }
+
+    /**
+     * Whitelist of fields that go to the related ProductDetail row.
+     */
+    public function productDetailAttributes(): array
+    {
+        return $this->safe()->only([
+            'description', 'lang1', 'lang2', 'lang3',
+        ]);
+    }
+}

--- a/app/Models/UnicentaModels/Product.php
+++ b/app/Models/UnicentaModels/Product.php
@@ -12,8 +12,15 @@ use Illuminate\Database\Eloquent\Model;
 
 class Product extends Model
 {
-    //
     use Uuids;
+
+    /**
+     * Default VAT factor applied when converting net <-> gross sell price
+     * for the admin product edit form. The legacy code hard-coded 1.1
+     * (10% IVA) throughout the controller; centralising it here means
+     * future tax-category-aware logic only has one place to change.
+     */
+    public const DEFAULT_VAT_FACTOR = 1.1;
 
     protected $table = 'products';
     public $timestamps = false;
@@ -28,6 +35,21 @@ class Product extends Model
     public function setPriceBuyAttribute($value)
     {
         $this->attributes['pricebuy'] = str_replace(',', '.', $value);
+    }
+
+    /**
+     * Gross (with-IVA) sell price. Read as $product->price_sell_gross,
+     * write as $product->price_sell_gross = '2,50'.
+     */
+    public function getPriceSellGrossAttribute(): float
+    {
+        return (float) $this->pricesell * self::DEFAULT_VAT_FACTOR;
+    }
+
+    public function setPriceSellGrossAttribute($value): void
+    {
+        $normalised = str_replace(',', '.', (string) $value);
+        $this->attributes['pricesell'] = ((float) $normalised) / self::DEFAULT_VAT_FACTOR;
     }
 
     protected $fillable = [

--- a/app/Policies/ProductPolicy.php
+++ b/app/Policies/ProductPolicy.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\User;
+use App\Models\UnicentaModels\Product;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class ProductPolicy
+{
+    use HandlesAuthorization;
+
+    public function viewAny(User $user): bool
+    {
+        return $user->isManager();
+    }
+
+    public function view(User $user, Product $product): bool
+    {
+        return $user->isManager();
+    }
+
+    public function create(User $user): bool
+    {
+        return $user->isManager();
+    }
+
+    public function update(User $user, Product $product): bool
+    {
+        return $user->isManager();
+    }
+
+    public function delete(User $user, Product $product): bool
+    {
+        return $user->isManager();
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -13,7 +13,7 @@ class AuthServiceProvider extends ServiceProvider
      * @var array
      */
     protected $policies = [
-        // 'App\Models\Model' => 'App\Policies\ModelPolicy',
+        \App\Models\UnicentaModels\Product::class => \App\Policies\ProductPolicy::class,
     ];
 
     /**

--- a/resources/views/admin/products/edit.blade.php
+++ b/resources/views/admin/products/edit.blade.php
@@ -2,22 +2,6 @@
 
 @php
     /** @var \App\Models\UnicentaModels\Product $product */
-    $allergens = [
-        'alerg_apio'        => ['file' => 'Apio.png',           'label' => 'Apio'],
-        'alerg_crustaceans' => ['file' => 'Crustaceans.png',    'label' => 'Marisco'],
-        'alerg_dairy'       => ['file' => 'DairyProducts.png',  'label' => 'Lácteo'],
-        'alerg_sulphites'   => ['file' => 'DioxideSulphites.png','label' => 'Sulfitos'],
-        'alerg_gluten'      => ['file' => 'Gluten.png',         'label' => 'Gluten'],
-        'alerg_lupins'      => ['file' => 'Lupins.png',         'label' => 'Altramuces'],
-        'alerg_mollusks'    => ['file' => 'Mollusks.png',       'label' => 'Moluscos'],
-        'alerg_egg'         => ['file' => 'Egg.png',            'label' => 'Huevo'],
-        'alerg_mustard'     => ['file' => 'Mustard.png',        'label' => 'Mostaza'],
-        'alerg_peanuts'     => ['file' => 'Peanuts.png',        'label' => 'Cacahuete'],
-        'alerg_peelfruits'  => ['file' => 'PeelFruits.png',     'label' => 'Frutos Secos'],
-        'alerg_sesame'      => ['file' => 'SesameGrains.png',   'label' => 'Sésamo'],
-        'alerg_soy'         => ['file' => 'Soy.png',            'label' => 'Soja'],
-        'alerg_fish'        => ['file' => 'Fish.png',           'label' => 'Pescado'],
-    ];
     $detail = $product->product_detail;
     $translationLanguages = $translationLanguages ?? [];
 @endphp
@@ -215,7 +199,7 @@
                                 <input type="number" step="0.01" inputmode="decimal" min="0"
                                        name="pricesell" id="pricesell"
                                        class="form-control @error('pricesell') is-invalid @enderror"
-                                       value="{{ old('pricesell', number_format(((float) $product->pricesell) * 1.1, 2, '.', '')) }}"
+                                       value="{{ old('pricesell', number_format($product->price_sell_gross, 2, '.', '')) }}"
                                        required>
                                 <div class="input-group-append">
                                     <span class="input-group-text">€</span>
@@ -288,28 +272,7 @@
                     <p class="small text-muted">
                         Pulsa un alérgeno para activarlo/desactivarlo. Se guarda al instante.
                     </p>
-                    <div class="d-flex flex-wrap" id="allergen-grid">
-                        @foreach ($allergens as $key => $a)
-                            @php
-                                $active = $detail && $detail->{$key};
-                            @endphp
-                            <button type="button"
-                                    class="btn p-2 m-1 toggleAlergen {{ $active ? 'btn-success' : 'btn-outline-secondary' }}"
-                                    data-toggle="popover"
-                                    data-trigger="hover"
-                                    data-placement="top"
-                                    data-content="{{ $a['label'] }}"
-                                    aria-label="{{ $a['label'] }}"
-                                    aria-pressed="{{ $active ? 'true' : 'false' }}"
-                                    data-active="{{ $active ? '1' : '0' }}"
-                                    data-allergen="{{ $key }}"
-                                    id="{{ $key }}">
-                                <img src="/img/allergens/{{ $a['file'] }}" alt="" width="32" height="32"
-                                     style="filter: {{ $active ? 'none' : 'grayscale(100%)' }};">
-                                <span class="d-block small mt-1">{{ $a['label'] }}</span>
-                            </button>
-                        @endforeach
-                    </div>
+                    <x-product.allergen-grid :product="$product" :detail="$detail" />
                 </div>
             </fieldset>
 

--- a/resources/views/components/product/allergen-grid.blade.php
+++ b/resources/views/components/product/allergen-grid.blade.php
@@ -1,0 +1,45 @@
+@props([
+    'product',
+    'detail' => null,
+])
+
+@php
+    $detail = $detail ?? ($product->product_detail ?? null);
+    $allergens = [
+        'alerg_apio'        => ['file' => 'Apio.png',           'label' => 'Apio'],
+        'alerg_crustaceans' => ['file' => 'Crustaceans.png',    'label' => 'Marisco'],
+        'alerg_dairy'       => ['file' => 'DairyProducts.png',  'label' => 'Lácteo'],
+        'alerg_sulphites'   => ['file' => 'DioxideSulphites.png','label' => 'Sulfitos'],
+        'alerg_gluten'      => ['file' => 'Gluten.png',         'label' => 'Gluten'],
+        'alerg_lupins'      => ['file' => 'Lupins.png',         'label' => 'Altramuces'],
+        'alerg_mollusks'    => ['file' => 'Mollusks.png',       'label' => 'Moluscos'],
+        'alerg_egg'         => ['file' => 'Egg.png',            'label' => 'Huevo'],
+        'alerg_mustard'     => ['file' => 'Mustard.png',        'label' => 'Mostaza'],
+        'alerg_peanuts'     => ['file' => 'Peanuts.png',        'label' => 'Cacahuete'],
+        'alerg_peelfruits'  => ['file' => 'PeelFruits.png',     'label' => 'Frutos Secos'],
+        'alerg_sesame'      => ['file' => 'SesameGrains.png',   'label' => 'Sésamo'],
+        'alerg_soy'         => ['file' => 'Soy.png',            'label' => 'Soja'],
+        'alerg_fish'        => ['file' => 'Fish.png',           'label' => 'Pescado'],
+    ];
+@endphp
+
+<div class="d-flex flex-wrap" id="allergen-grid">
+    @foreach ($allergens as $key => $a)
+        @php $active = $detail && $detail->{$key}; @endphp
+        <button type="button"
+                class="btn p-2 m-1 toggleAlergen {{ $active ? 'btn-success' : 'btn-outline-secondary' }}"
+                data-toggle="popover"
+                data-trigger="hover"
+                data-placement="top"
+                data-content="{{ $a['label'] }}"
+                aria-label="{{ $a['label'] }}"
+                aria-pressed="{{ $active ? 'true' : 'false' }}"
+                data-active="{{ $active ? '1' : '0' }}"
+                data-allergen="{{ $key }}"
+                id="{{ $key }}">
+            <img src="/img/allergens/{{ $a['file'] }}" alt="" width="32" height="32"
+                 style="filter: {{ $active ? 'none' : 'grayscale(100%)' }};">
+            <span class="d-block small mt-1">{{ $a['label'] }}</span>
+        </button>
+    @endforeach
+</div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Last of four PRs improving the product edit page. **Stacked on PR #11** (layout/UX) → PR #10 (image/payload) → PR #9 (correctness/security).

Pure refactor — no behavioural change visible to the user. Same end-to-end smoke tests that pass on PR #11 still pass here.

## Changes

### `app/Http/Requests/`
Extract validation + payload normalisation out of the controller into typed FormRequests:

- `StoreProductRequest`, `UpdateProductRequest` — own the rules and expose typed `productAttributes()` / `productDetailAttributes()` helpers that return only the whitelisted fields (replaces the inline `Arr::only()` calls).
- `AddOnProductRequest`, `RemoveAddOnProductRequest` — validate addon payloads (require existing product ids); `AddOnProductRequest::priceAsFloat()` normalises comma-decimals (`"2,99" → 2.99`).
- `ToggleAllergenRequest` — validates `alergen_id` against `ProductDetail::ALLERGEN_KEYS` so the controller no longer carries the whitelist literal.
- All five `authorize()` against `User::isManager()` so request-level auth aligns with the route middleware.

### `app/Policies/ProductPolicy.php`
New policy with `viewAny` / `view` / `create` / `update` / `delete` checks delegating to `User::isManager()`. Registered in `AuthServiceProvider::$policies`.

`ProductController` now calls `$this->authorize('update', $product)` (and `create` / `delete`) so the authorization is explicit and the same checks can be reused outside HTTP routes (jobs, console commands, future API).

### `app/Models/UnicentaModels/Product.php` — VAT moved into the model
- `Product::DEFAULT_VAT_FACTOR = 1.1` constant — replaces the magic `1.1` previously scattered through the controller.
- New `price_sell_gross` accessor + mutator: read computes `pricesell * factor`, write divides the incoming gross value by the factor and stores the net.

The controller now does:
```php
$product->price_sell_gross = $request->input('pricesell');
```
instead of inline `str_replace(',', '.', …) / 1.1`. Future tax-category-aware logic (PR #9 already noted that the `1.1` is wrong for products on a different `taxcat`) only has to change `Product::DEFAULT_VAT_FACTOR` / the accessor.

### `app/Http/Controllers/ProductController.php`
- `store(StoreProductRequest)`, `update(UpdateProductRequest, $id)`, `addOnProductAdd(AddOnProductRequest)`, `removeAddOnProductAdd(RemoveAddOnProductRequest)`, `toggleAlergen(ToggleAllergenRequest)` — type-hinted FormRequest dependencies replace inline `validate()` calls.
- `updateProductDetail()` takes an array (from the FormRequest) and uses `ProductDetail::firstOrNew()->fill()`.
- Drop now-unused `Illuminate\Support\Arr` / `Redirect` imports.

### `resources/views/components/product/allergen-grid.blade.php` (new)
Extract the 14-allergen grid into `<x-product.allergen-grid />` so it can be reused from `create.blade.php` (and any future product form).

### `resources/views/admin/products/edit.blade.php`
- Inline allergens replaced with `<x-product.allergen-grid :product="$product" :detail="$detail" />`.
- Pricing input now uses `$product->price_sell_gross` instead of `((float) $product->pricesell) * 1.1`.

## Testing

End-to-end smoke against the running app, after the refactor:

- ✅ `GET /products/prod-cana/edit` → 200, allergen grid renders 14 buttons via the new component.
- ✅ `PATCH /products/prod-cana` with `pricesell=2.20` → DB stores `pricesell = 2.0000` (= 2.20 / 1.1, via the new mutator).
- ✅ `POST /product/alergen` with valid key → `{status:true, active:true}`; with `alergen_id=description` → `422` (whitelist still enforced via `Rule::in`).
- ✅ `POST /addOnProduct/add` with `price=2,99` → DB stores `price = 2.99` (comma-decimal normalised by `priceAsFloat()`).
- ✅ `POST /addOnProduct/remove` → 200 and row deleted.
- ✅ `redirects_to=https://evil.example.com` → 302 to edit page (open-redirect still blocked).
- ✅ `php -l` clean on all PHP files; `php artisan view:cache` compiles all blade templates including the new component.

The rebuilt UI screenshots and demo video from PR #11 still apply unchanged — this PR has no UI-visible delta.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-79376bd7-036d-4d25-bc99-57d7e5b38fb9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-79376bd7-036d-4d25-bc99-57d7e5b38fb9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

