### PR TITLE
Product edit: correctness, security, image, layout & refactor (ported to main)

### DIFF
--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -2,213 +2,164 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\AddOnProductRequest;
+use App\Http\Requests\RemoveAddOnProductRequest;
+use App\Http\Requests\StoreProductRequest;
+use App\Http\Requests\ToggleAllergenRequest;
+use App\Http\Requests\UpdateProductRequest;
+use App\Models\ProductAdOn;
 use App\Models\ProductDetail;
 use App\Models\UnicentaModels\Category;
-use App\Models\ProductAdOn;
-use App\Traits\ProductTrait;
 use App\Models\UnicentaModels\Product;
 use App\Models\UnicentaModels\Products_Cat;
+use App\Traits\ProductTrait;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Facades\Redirect;
-use function str_replace;
-use function view;
 
 class ProductController extends Controller
 {
     use ProductTrait;
-    /**
-     * Display a listing of the resource.
-     *
-     * @return \Illuminate\Http\Response
-     */
-    public function index($category=null)
+
+    public function index($category = null)
     {
-        //
-        if(empty($category)) {
+        if (empty($category)) {
             $products = Product::paginate(50);
-        }else{
-            $products= $this->getCategoryProducts($category);
-    }
+        } else {
+            $products = $this->getCategoryProducts($category);
+        }
+
         $categories = Category::orderByRaw('CONVERT(catorder, SIGNED)')->get();
 
-        return view('admin.products.index',compact('categories','products'))
+        return view('admin.products.index', compact('categories', 'products'))
             ->with('i', (request()->input('page', 1) - 1) * 5);
     }
 
-    /**
-     * Show the form for creating a new resource.
-     *
-     * @return \Illuminate\Http\Response
-     */
     public function create()
     {
-        //
+        $this->authorize('create', Product::class);
+
         $categories = Category::all();
-        return view('admin.products.create',compact('categories'));
+        return view('admin.products.create', compact('categories'));
     }
 
-    /**
-     * Store a newly created resource in storage.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\Http\Response
-     */
-    public function store(Request $request)
+    public function store(StoreProductRequest $request)
     {
-        //
-        $request->validate([
-            'code'=> 'required',
-            'reference'=> 'required',
-            'category'=> 'required',
-            'pricebuy'=> 'required',
-            'pricesell'=> 'required',
-            'name' => 'required',
+        $attrs = $request->productAttributes();
 
-        ]);
+        $product = Product::create($attrs);
 
+        // The form posts a gross (with-IVA) sell price; convert it back to net
+        // so it matches what the rest of the application stores.
+        $product->price_sell_gross = $request->input('pricesell');
+        $product->save();
 
-        Product::create($request->all());
+        $this->addOrDeleteFromCatalog($product->id);
 
-
-        $code = request()->get('code');
-
-        $createdProduct = Product::where('code', $code)->first();
-
-        $pricesell = str_replace(',','.',$request->pricesell);
-        $createdProduct->pricesell = $pricesell /1.1;
-        $createdProduct->save();
-        $product_id = $createdProduct->id;
-        $this->addOrDeleteFromCatalog($product_id);
-
-        return redirect()->route('products.edit',$product_id )
-            ->with('success','Product created successfully.');
+        return redirect()->route('products.edit', $product->id)
+            ->with('success', 'Product created successfully.');
     }
 
-    /**
-     * Display the specified resource.
-     *
-     * @param  int  $id
-     * @return \Illuminate\Http\Response
-     */
     public function show($product)
     {
-        //
-        return view('products.show',compact('product'));
+        return view('products.show', compact('product'));
     }
 
-    /**
-     * Show the form for editing the specified resource.
-     *
-     * @param  int  $id
-     * @return \Illuminate\Http\Response
-     */
     public function edit($id)
     {
-        //
-        $product=Product::findOrFail($id);
+        $product = Product::with('product_detail')->findOrFail($id);
+        $this->authorize('update', $product);
 
-        if (!empty($product->image)) {
-            $product->image = base64_encode($product->image);
-        }
+        $hasImage = ! empty($product->image);
 
-        $product_addons = ProductAdOn::where('product_id','=',$product->id)->get();
-       // dd($product_addons);
-        $all_adons=[];
-        foreach ($product_addons as $product_addon) {
-            $all_adons[]= Product::find($product_addon->adon_product_id);
-        }
+        $addonIds = ProductAdOn::where('product_id', $product->id)->pluck('adon_product_id');
+        $all_adons = $addonIds->isEmpty()
+            ? collect()
+            : Product::whereIn('id', $addonIds)->get();
 
-        $categories = Category::all();
+        $categories = Category::orderBy('name')->get();
 
+        $languages = config('languages', []);
+        // Strip the default (first) language and keep the next three —
+        // these correspond to product_details.lang1, lang2, lang3.
+        $translationLanguages = array_slice($languages, 1, 3, true);
 
-        return view('admin.products.edit',compact('product','all_adons','categories'));
+        return view('admin.products.edit', compact(
+            'product',
+            'all_adons',
+            'categories',
+            'hasImage',
+            'translationLanguages'
+        ));
     }
 
-    /**
-     * Update the specified resource in storage.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  int  $id
-     * @return \Illuminate\Http\Response
-     */
-    public function update(Request $request, $id)
+    public function update(UpdateProductRequest $request, $id)
     {
-        //
+        Log::debug('product update id:' . $id);
 
-        $request->validate([
-            'code'=> 'required',
-            'taxcat'=> 'required',
-            'reference'=> 'required',
-            'category'=> 'required',
-            'pricebuy'=> 'required',
-            'pricesell'=> 'required',
-            'name' => 'required',
+        $product = Product::findOrFail($id);
+        $this->authorize('update', $product);
 
-        ]);
-        Log::debug('product update id:'.$id);
+        $product->fill($request->productAttributes());
+        $product->printto = trim((string) $request->input('printto', $product->printto));
+        $product->price_sell_gross = $request->input('pricesell');
 
-
-        $product=Product::find($id);
-        $request->validate([
-            'name' => 'required',
-            'pricebuy' => 'required',
-        ]);
-
-
-        $product->update($request->all());
-        $pricesell = str_replace(',','.',$request->pricesell);
-        $stockunits = str_replace(',','.',$request->stockunits);
-        $product->pricesell = ($pricesell/1.1);
-        $product->stockunits = $stockunits;
-        $product->save();
-        $this->updateProductDetail($request,$id);
-
-        $url = $request->only('redirects_to');
-
-        return redirect()->to($url['redirects_to']);
-        //return redirect()->route('products.index')->with('success','Product updated successfully');
-    }
-
-    private function updateProductDetail(Request $request,$id){
-
-        $productDetail = ProductDetail::where('product_id',$id)->first();
-        if(empty($productDetail)){
-            $productDetail = new ProductDetail();
-            $productDetail->product_id = $id;
+        $stockunits = $request->input('stockunits');
+        if ($stockunits !== null && $stockunits !== '') {
+            $product->stockunits = str_replace(',', '.', $stockunits);
         }
-        $productDetail->description = $request->description;
-        $productDetail->lang1=$request->lang1;
-        $productDetail->lang2=$request->lang2;
-        $productDetail->lang3=$request->lang3;
-        $productDetail->save();
 
+        $product->save();
+        $this->updateProductDetail($request->productDetailAttributes(), $product->id);
 
-
+        return $this->safeRedirect(
+            $request->input('redirects_to'),
+            route('products.edit', $product->id)
+        )->with('success', 'Product updated successfully');
     }
 
     /**
-     * Remove the specified resource from storage.
-     *
-     * @param  int  $id
-     * @return \Illuminate\Http\Response
+     * Validate the supplied URL is a same-host path before redirecting.
+     * Falls back to $fallback otherwise. Prevents open-redirects.
      */
+    private function safeRedirect(?string $candidate, string $fallback)
+    {
+        if (empty($candidate)) {
+            return redirect()->to($fallback);
+        }
+
+        $appHost = parse_url(config('app.url'), PHP_URL_HOST);
+        $targetHost = parse_url($candidate, PHP_URL_HOST);
+
+        if ($targetHost === null || $targetHost === $appHost) {
+            return redirect()->to($candidate);
+        }
+
+        return redirect()->to($fallback);
+    }
+
+    private function updateProductDetail(array $attrs, $productId): void
+    {
+        $detail = ProductDetail::firstOrNew(['product_id' => $productId]);
+        $detail->fill($attrs);
+        $detail->save();
+    }
+
     public function destroy($id)
     {
-        //
-        $product=Product::findOrFail($id);
+        $product = Product::findOrFail($id);
+        $this->authorize('delete', $product);
+
         $product->product_cat()->delete();
         $product->delete();
 
         return redirect()->route('products.index')
-            ->with('success','Product deleted successfully');
+            ->with('success', 'Product deleted successfully');
     }
 
     public function editImage($id)
     {
-
         $product = Product::find($id);
-        if (!empty($product->image)) {
+        if (! empty($product->image)) {
             $product->image = base64_encode($product->image);
         }
 
@@ -219,44 +170,53 @@ class ProductController extends Controller
     {
         $image_file = $request->image;
         $product = Product::find($request->productID);
-        list($type, $image_file) = explode(';', $image_file);
+        list(, $image_file) = explode(';', $image_file);
         list(, $image_file) = explode(',', $image_file);
         $image_file = base64_decode($image_file);
         $product->image = $image_file;
         $product->save();
         return response()->json(['status' => true]);
     }
-    public function toggleCatalog(Request $request){
+
+    public function toggleCatalog(Request $request)
+    {
         $product_id = $request->product_id;
-        Log::debug('product_id:'.$product_id);
+        Log::debug('product_id:' . $product_id);
 
         $this->addOrDeleteFromCatalog($product_id);
 
-        return "SUCCES";
-
+        return 'SUCCES';
     }
 
-    public function addOnProductAdd(){
-        ProductAdOn::create(request()->all());
-        return true;
-    }
-    public function removeAddOnProductAdd(){
-        $productID = request()->get('product_id');
-        $addonProductID = request()->get('adon_product_id');
-        $product = ProductAdOn::where('product_id',$productID)->where('adon_product_id',$addonProductID)->first();
-        $product->delete();
-        return true;
+    public function addOnProductAdd(AddOnProductRequest $request)
+    {
+        ProductAdOn::create([
+            'product_id'      => $request->input('product_id'),
+            'adon_product_id' => $request->input('adon_product_id'),
+            'price'           => $request->priceAsFloat(),
+        ]);
+
+        return response()->json(['status' => true]);
     }
 
-    /**
-     * @param $product_id
-     */
+    public function removeAddOnProductAdd(RemoveAddOnProductRequest $request)
+    {
+        $row = ProductAdOn::where('product_id', $request->input('product_id'))
+            ->where('adon_product_id', $request->input('adon_product_id'))
+            ->first();
+
+        if ($row !== null) {
+            $row->delete();
+        }
+
+        return response()->json(['status' => true]);
+    }
+
     private function addOrDeleteFromCatalog($product_id): void
     {
         $productcat = Products_Cat::find($product_id);
         if (empty($productcat)) {
             $cat = new Products_Cat();
-
             $cat->product = $product_id;
             $cat->save();
         } else {
@@ -264,26 +224,21 @@ class ProductController extends Controller
         }
     }
 
-    public function getProductList($id){
-        return Product::select('id','name')->where('category',$id)->get();
+    public function getProductList($id)
+    {
+        return Product::select('id', 'name')->where('category', $id)->get();
     }
 
-    public function toggleAlergen(Request $request){
-        $productID = request()->get('product_id');
-        $productDetail = ProductDetail::where('product_id',$productID)->first();
-        if(empty($productDetail)){
-            $productDetail = new ProductDetail();
-            $productDetail->product_id = $productID;
-        }
-        if($productDetail->{$request->alergen_id}){
-            $productDetail->{$request->alergen_id} = false;
-        }else{
-            $productDetail->{$request->alergen_id} = true;
-        }
+    public function toggleAlergen(ToggleAllergenRequest $request)
+    {
+        $productDetail = ProductDetail::firstOrNew(['product_id' => $request->input('product_id')]);
+        $key = $request->input('alergen_id');
+        $productDetail->{$key} = ! (bool) $productDetail->{$key};
         $productDetail->save();
-        return $productDetail->{$request->alergen_id};
 
+        return response()->json([
+            'status' => true,
+            'active' => (bool) $productDetail->{$key},
+        ]);
     }
-
-
 }

--- a/app/Http/Requests/AddOnProductRequest.php
+++ b/app/Http/Requests/AddOnProductRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class AddOnProductRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        $user = $this->user();
+        return $user !== null && method_exists($user, 'isManager') && $user->isManager();
+    }
+
+    public function rules(): array
+    {
+        return [
+            'product_id'      => 'required|string|exists:products,id',
+            'adon_product_id' => 'required|string|exists:products,id',
+            'price'           => 'nullable',
+        ];
+    }
+
+    public function priceAsFloat(): ?float
+    {
+        $raw = $this->input('price');
+        if ($raw === null || $raw === '') {
+            return null;
+        }
+        return (float) str_replace(',', '.', (string) $raw);
+    }
+}

--- a/app/Http/Requests/RemoveAddOnProductRequest.php
+++ b/app/Http/Requests/RemoveAddOnProductRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class RemoveAddOnProductRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        $user = $this->user();
+        return $user !== null && method_exists($user, 'isManager') && $user->isManager();
+    }
+
+    public function rules(): array
+    {
+        return [
+            'product_id'      => 'required|string|exists:products,id',
+            'adon_product_id' => 'required|string|exists:products,id',
+        ];
+    }
+}

--- a/app/Http/Requests/StoreProductRequest.php
+++ b/app/Http/Requests/StoreProductRequest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreProductRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        $user = $this->user();
+        return $user !== null && method_exists($user, 'isManager') && $user->isManager();
+    }
+
+    public function rules(): array
+    {
+        return [
+            'code'      => 'required|string|max:255',
+            'reference' => 'required|string|max:255',
+            'category'  => 'required|string|max:255',
+            'pricebuy'  => 'required',
+            'pricesell' => 'required',
+            'name'      => 'required|string|max:255',
+            'taxcat'    => 'nullable|string|max:255',
+            'printto'   => 'nullable|string|max:255',
+        ];
+    }
+
+    /**
+     * Whitelist of fields that may be assigned directly to the Product model.
+     */
+    public function productAttributes(): array
+    {
+        return $this->safe()->only([
+            'name', 'pricebuy', 'pricesell', 'code', 'reference', 'taxcat', 'category', 'printto',
+        ]);
+    }
+}

--- a/app/Http/Requests/ToggleAllergenRequest.php
+++ b/app/Http/Requests/ToggleAllergenRequest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Models\ProductDetail;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class ToggleAllergenRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        $user = $this->user();
+        return $user !== null && method_exists($user, 'isManager') && $user->isManager();
+    }
+
+    public function rules(): array
+    {
+        return [
+            'product_id' => 'required|string|exists:products,id',
+            'alergen_id' => ['required', 'string', Rule::in(ProductDetail::ALLERGEN_KEYS)],
+        ];
+    }
+}

--- a/app/Http/Requests/UpdateProductRequest.php
+++ b/app/Http/Requests/UpdateProductRequest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateProductRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        $user = $this->user();
+        return $user !== null && method_exists($user, 'isManager') && $user->isManager();
+    }
+
+    public function rules(): array
+    {
+        return [
+            'code'        => 'required|string|max:255',
+            'taxcat'      => 'required|string|max:255',
+            'reference'   => 'required|string|max:255',
+            'category'    => 'required|string|max:255',
+            'pricebuy'    => 'required',
+            'pricesell'   => 'required',
+            'name'        => 'required|string|max:255',
+            'printto'     => 'nullable|string|max:255',
+            'stockunits'  => 'nullable|string|max:255',
+            'description' => 'nullable|string',
+            'lang1'       => 'nullable|string|max:255',
+            'lang2'       => 'nullable|string|max:255',
+            'lang3'       => 'nullable|string|max:255',
+        ];
+    }
+
+    /**
+     * Whitelist of fields that may be assigned directly to the Product model.
+     * Excludes pricesell/printto/stockunits because the controller normalises
+     * them before assignment.
+     */
+    public function productAttributes(): array
+    {
+        return $this->safe()->only([
+            'name', 'code', 'reference', 'category', 'taxcat', 'pricebuy',
+        ]);
+    }
+
+    /**
+     * Whitelist of fields that go to the related ProductDetail row.
+     */
+    public function productDetailAttributes(): array
+    {
+        return $this->safe()->only([
+            'description', 'lang1', 'lang2', 'lang3',
+        ]);
+    }
+}

--- a/app/Models/ProductDetail.php
+++ b/app/Models/ProductDetail.php
@@ -17,6 +17,7 @@ class ProductDetail extends Model
         'lang1',
         'lang2',
         'lang3',
+        'alerg_apio',
         'alerg_crustaceans',
         'alerg_dairy',
         'alerg_sulphites',
@@ -27,7 +28,26 @@ class ProductDetail extends Model
         'alerg_mustard',
         'alerg_peanuts',
         'alerg_peelfruits',
-        'alerg_sesame'
+        'alerg_sesame',
+        'alerg_soy',
+        'alerg_fish',
+    ];
+
+    public const ALLERGEN_KEYS = [
+        'alerg_apio',
+        'alerg_crustaceans',
+        'alerg_dairy',
+        'alerg_sulphites',
+        'alerg_egg',
+        'alerg_gluten',
+        'alerg_lupins',
+        'alerg_mollusks',
+        'alerg_mustard',
+        'alerg_peanuts',
+        'alerg_peelfruits',
+        'alerg_sesame',
+        'alerg_soy',
+        'alerg_fish',
     ];
 
 

--- a/app/Models/UnicentaModels/Product.php
+++ b/app/Models/UnicentaModels/Product.php
@@ -12,8 +12,15 @@ use Illuminate\Database\Eloquent\Model;
 
 class Product extends Model
 {
-    //
     use Uuids;
+
+    /**
+     * Default VAT factor applied when converting net <-> gross sell price
+     * for the admin product edit form. The legacy code hard-coded 1.1
+     * (10% IVA) throughout the controller; centralising it here means
+     * future tax-category-aware logic only has one place to change.
+     */
+    public const DEFAULT_VAT_FACTOR = 1.1;
 
     protected $table = 'products';
     public $timestamps = false;
@@ -28,6 +35,21 @@ class Product extends Model
     public function setPriceBuyAttribute($value)
     {
         $this->attributes['pricebuy'] = str_replace(',', '.', $value);
+    }
+
+    /**
+     * Gross (with-IVA) sell price. Read as $product->price_sell_gross,
+     * write as $product->price_sell_gross = '2,50'.
+     */
+    public function getPriceSellGrossAttribute(): float
+    {
+        return (float) $this->pricesell * self::DEFAULT_VAT_FACTOR;
+    }
+
+    public function setPriceSellGrossAttribute($value): void
+    {
+        $normalised = str_replace(',', '.', (string) $value);
+        $this->attributes['pricesell'] = ((float) $normalised) / self::DEFAULT_VAT_FACTOR;
     }
 
     protected $fillable = [

--- a/app/Policies/ProductPolicy.php
+++ b/app/Policies/ProductPolicy.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\User;
+use App\Models\UnicentaModels\Product;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class ProductPolicy
+{
+    use HandlesAuthorization;
+
+    public function viewAny(User $user): bool
+    {
+        return $user->isManager();
+    }
+
+    public function view(User $user, Product $product): bool
+    {
+        return $user->isManager();
+    }
+
+    public function create(User $user): bool
+    {
+        return $user->isManager();
+    }
+
+    public function update(User $user, Product $product): bool
+    {
+        return $user->isManager();
+    }
+
+    public function delete(User $user, Product $product): bool
+    {
+        return $user->isManager();
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -13,7 +13,7 @@ class AuthServiceProvider extends ServiceProvider
      * @var array
      */
     protected $policies = [
-        // 'App\Models\Model' => 'App\Policies\ModelPolicy',
+        \App\Models\UnicentaModels\Product::class => \App\Policies\ProductPolicy::class,
     ];
 
     /**

--- a/resources/views/admin/products/crop_image.blade.php
+++ b/resources/views/admin/products/crop_image.blade.php
@@ -61,7 +61,9 @@
                     data: {"image": img, "productID": "{{ $product->id }}"},
                     success: function () {
                         jQuery("#upload-success").html("Images cropped and uploaded successfully.").removeClass('hidden');
-                        window.location.href = "/products/{{ $product->id }}/edit";
+                        var params = new URLSearchParams(window.location.search);
+                        var fallback = "/products/{{ $product->id }}/edit";
+                        window.location.href = params.get('redirects_to') || fallback;
                     }
                 });
             });

--- a/resources/views/admin/products/edit.blade.php
+++ b/resources/views/admin/products/edit.blade.php
@@ -1,261 +1,473 @@
 @extends('layouts.admin')
 
-@section('title', __('Product') . ' — ' . config('app.name'))
-
-@section('page_header')
-    <h1 class="text-2xl font-bold text-slate-900">{{ __('Editar producto') }}</h1>
-@endsection
+@section('title', __('Editar producto') . ' — ' . config('app.name'))
 
 @section('page', 'product-edit')
 
-@section('content')
-    <div class="card-tw max-w-5xl">
-        <div id="ProductName" class="card-tw-header text-center">{{ __('Product') }}</div>
-        <div class="card-tw-body text-left">
-
-                    <form id="product-edit-form" data-product-id="{{ $product->id }}" action="{{ route('products.update',$product->id) }}" method="POST"
-                          class="space-y-8">
-
-                        <input type="hidden" name="redirects_to" value="{{ URL::previous() }}">
-                        @method('PATCH')
-                        @csrf
-
-
-                        <div class="space-y-6">
-                        <table class="w-full border-collapse text-sm">
-                            <tr>
-                                <td colspan="3">
-                                    <label for="name" class="form-label"><b>Nombre</b></label>
-                                    <input name="name" class="input-tw w-full" type="text" value="{{$product->name}}" style="min-width: 100%">
-
-                                </td>
-                            </tr>
-                            <tr><td><h6 class="inline-flex bg-dark text-white mt-4">Image</h6></td><td><hr></td><td><hr></td></tr>
-
-                            <tr>
-                                <td colspan="2">
-                                    <img src="data:image/png;base64,{{$product->image}}">
-                                </td>
-                                <td>
-                                    <a href="/crop-image/{{$product->id}}" class="btn btn-tab">
-                                        Edit Image
-                                    </a>
-                                </td>
-                            </tr>
-                            <tr><td><h6 class="inline-flex bg-dark text-white mt-4">Descripcion</h6></td><td><hr></td><td><hr></td></tr>
-                            <tr>
-                                <td colspan="3">
-                                    <label for="description" class="form-label"><b>Dicripcion</b></label>
-                                    <textarea name="description" class="input-tw w-full"
-                                              rows="3" size="12" style="min-width: 100%">{{$product->product_detail->description ?? ''}}</textarea>
-
-                                </td>
-                            </tr>
-                            <tr><td><h6 class="inline-flex bg-dark text-white mt-4">Categoria</h6></td><td><hr></td><td><hr></td></tr>
-
-
-                            <tr>
-
-                                <td colspan="1 ">
-                                    <label for="category" class="label label-default"><b>Categoria</b> </label>
-                                    <select name="category" class="input-tw w-full">
-                                        @foreach($categories as $category)
-                                            <option value="{{$category->id}}" {{ ( $category->id == $product->category) ? 'selected' : '' }}>
-                                                {{$category->name}}
-                                            </option>
-
-                                        @endforeach
-                                    </select>
-                                </td>
-                                <td colspan="1">
-                                    <label for="printto" class="form-label"><b>Printer Nr</b></label>
-                                    <input name="printto" class="input-tw w-full" type="text" size="2"
-                                           value="{{$product->printto ?? '1'}} ">
-
-                                </td>
-                                <td>
-                                    <label for="taxcat" class="form-label"><b>Tipo de IVA</b></label>
-                                    <input name="taxcat" class="input-tw w-full" type="text" value="001" size="2" readonly>
-
-                                </td>
-                            </tr>
-                            <tr>
-
-                            </tr>
-                            <tr><td><h6 class="inline-flex bg-dark text-white mt-4">System data</h6></td><td><hr></td><td><hr></td></tr>
-                        <tr>
-
-                                <td colspan="2">
-                                    <label for="reference" class="label label-default"><b>Referencia</b> </label>
-                                    <input name="reference" class="input-tw w-full" type="text"
-                                           value="{{$product->reference}}" readonly>
-                                </td>
-                                <td>
-                                    <label for="code" class="form-label"><b>Codigo</b></label>
-                                    <input name="code" class="input-tw w-full" type="text"
-                                           value="{{$product->code}}" readonly>
-
-                                </td>
-                            </tr>
-
-
-                            <tr><td><h6 class="inline-flex bg-dark text-white mt-4">Compra y Venta</h6></td><td><hr></td><td><hr></td></tr>
-
-                            <tr>
-
-                                <td colspan="1">
-                                    <label for="stockunits" class="label label-default"><b>Unidades de stock</b>
-                                    </label>
-                                    <input name="stockunits" class="input-tw w-full" type="text" size="3"
-                                           value="{{$product->stockunits}}">
-                                </td>
-
-
-                                <td>
-                                    <label for="pricebuy" class="form-label"><b>Compra (sin IVA)</b> </label>
-                                    <input name="pricebuy" class="input-tw w-full" type="text" size="3"
-                                           value="{{$product->pricebuy}}">€
-
-                                </td>
-                                <td>
-                                    <label for="pricesell" class="form-label"><b>Venta (con IVA)</b></label>
-                                    <input name="pricesell" class="input-tw w-full" type="text" size="3"
-                                           value="{{($product->pricesell *1.1)}}">€
-
-                                </td>
-                            </tr>
-                            <tr>
-                                <td><h6 class="inline-flex bg-dark text-white mt-4">Extras a Añadir</h6></td>
-                                <td>
-                                    <hr>
-                                </td>
-                                <td>
-                                    <hr>
-                                </td>
-                            </tr>
-
-
-                            <tr>
-                                <td colspan="3" class="text-left">
-                                    <label for="category_addon" class="form-label"><b>Seleccion de añadidos</b></label>
-                                    <select class="input-tw w-full" name="category_addon" id="category_addon">
-                                        @foreach($categories as $categorie)
-                                            <option value="{{$categorie->id}}">{{$categorie->name}}</option>
-
-                                        @endforeach
-                                    </select></td>
-                            </tr>
-
-                            <tr>
-
-                                <td colspan="2">
-                                    <label for="products_list" class="form-label">Disponibles</label>
-
-                                    <select name="products_list" class="input-tw w-full"
-                                            id="products_list">
-
-
-                                    </select>
-
-                                </td>
-                                <td colspan="1">
-                                    <label for="addon_products_list" class="form-label">Selecionados</label>
-                                    <select name="addon_products_list" class="input-tw w-full"
-                                            id="addon_products_list">
-                                        <option value=""></option>
-                                        @foreach($all_adons as $all_adon)
-
-                                            <option value="{{$all_adon->id}}">{{$all_adon->name}}</option>
-                                        @endforeach
-
-                                    </select>
-
-                                </td>
-                            </tr>
-                            <tr><td><h6 class="inline-flex bg-dark text-white mt-4">Alergenicos</h6></td><td><hr></td><td><hr></td></tr>
-                            <tr>
-                                <td colspan="3">
-                                    <img
-                                            src="/img/allergens/Apio.png" class="img-fluid toggleAlergen"
-                                            width="32" data-container="body" data-toggle="popover" data-placement="top" data-content="Apio" id='alerg_apio' style=" opacity:@if($product->product_detail AND $product->product_detail->alerg_apio) 1 @else 0.3 @endif;">
-                                    <img
-                                            src="/img/allergens/Crustaceans.png" class="img-fluid toggleAlergen"
-                                            width="32" data-container="body" data-toggle="popover" data-placement="top" data-content="Marisco" id='alerg_crustaceans' style=" opacity:@if($product->product_detail AND $product->product_detail->alerg_crustaceans) 1 @else 0.3 @endif;">
-                                    <img
-                                            src="/img/allergens/DairyProducts.png" class="img-fluid toggleAlergen"
-                                            width="32" data-container="body" data-toggle="popover" data-placement="top" data-content="Lacteo" id='alerg_dairy' style=" opacity:@if($product->product_detail AND $product->product_detail->alerg_dairy) 1 @else 0.3 @endif;">
-                                    <img
-                                            src="/img/allergens/DioxideSulphites.png" class="img-fluid toggleAlergen"
-                                            width="32" data-container="body" data-toggle="popover" data-placement="top" data-content="Sulphite" id='alerg_sulphites' style=" opacity:@if($product->product_detail AND $product->product_detail->alerg_sulphites) 1 @else 0.3 @endif;">
-                                    <img
-                                            src="/img/allergens/Gluten.png" class="img-fluid toggleAlergen"
-                                            width="32" data-container="body" data-toggle="popover" data-placement="top" data-content="Gluten" id='alerg_gluten' style=" opacity:@if($product->product_detail AND $product->product_detail->alerg_gluten) 1 @else 0.3 @endif;">
-                                    <img
-                                            src="/img/allergens/Lupins.png" class="img-fluid toggleAlergen"
-                                            width="32" data-container="body" data-toggle="popover" data-placement="top" data-content="Altramuces" id='alerg_lupins' style=" opacity:@if($product->product_detail AND $product->product_detail->alerg_lupins) 1 @else 0.3 @endif;">
-                                    <img
-                                            src="/img/allergens/Mollusks.png" class="img-fluid toggleAlergen"
-                                            width="32" data-container="body" data-toggle="popover" data-placement="top" data-content="Moluscos" id='alerg_mollusks' style=" opacity:@if($product->product_detail AND $product->product_detail->alerg_mollusks) 1 @else 0.3 @endif;">
-                                    <img
-                                            src="/img/allergens/Egg.png" class="img-fluid toggleAlergen"
-                                            width="32" data-container="body" data-toggle="popover" data-placement="top" data-content="Huevo" id='alerg_egg' style=" opacity:@if($product->product_detail AND $product->product_detail->alerg_egg) 1 @else 0.3 @endif;">
-                                    <img
-                                            src="/img/allergens/Mustard.png" class="img-fluid toggleAlergen"
-                                            width="32" data-container="body" data-toggle="popover" data-placement="top" data-content="Mostaza" id='alerg_mustard' style=" opacity:@if($product->product_detail AND $product->product_detail->alerg_mustard) 1 @else 0.3 @endif;">
-                                    <img
-                                            src="/img/allergens/Peanuts.png" class="img-fluid toggleAlergen"
-                                            width="32" data-container="body" data-toggle="popover" data-placement="top" data-content="Cacahuete" id='alerg_peanuts' style=" opacity:@if($product->product_detail AND $product->product_detail->alerg_peanuts) 1 @else 0.3 @endif;">
-                                    <img
-                                            src="/img/allergens/PeelFruits.png" class="img-fluid toggleAlergen"
-                                            width="32" data-container="body" data-toggle="popover" data-placement="top" data-content="Frutos Secos" id='alerg_peelfruits' style=" opacity:@if($product->product_detail AND $product->product_detail->alerg_peelfruits) 1 @else 0.3 @endif;">
-                                    <img
-                                            src="/img/allergens/SesameGrains.png" class="img-fluid toggleAlergen"
-                                            width="32" data-container="body" data-toggle="popover" data-placement="top" data-content="Sesamo"id='alerg_sesame'  style=" opacity:@if($product->product_detail AND $product->product_detail->alerg_sesame) 1 @else 0.3 @endif;">
-                                    <img
-                                            src="/img/allergens/Soy.png" class="img-fluid toggleAlergen"
-                                            width="32" data-container="body" data-toggle="popover" data-placement="top" data-content="Soy"id='alerg_soy'  style=" opacity:@if($product->product_detail AND $product->product_detail->alerg_soy) 1 @else 0.3 @endif;">
-                                    <img
-                                            src="/img/allergens/Fish.png" class="img-fluid toggleAlergen"
-                                            width="32" data-container="body" data-toggle="popover" data-placement="top" data-content="Fish"id='alerg_fish'  style=" opacity:@if($product->product_detail AND $product->product_detail->alerg_fish) 1 @else 0.3 @endif;">
-
-                                </td>
-
-                            </tr>
-
-                            <tr><td><h6 class="inline-flex bg-dark text-white mt-4">Traduciones</h6></td><td><hr></td><td><hr></td></tr>
-                            <tr>
-                                <td colspan="3">
-
-                                    <label for="lang1" class="form-label"><img src="/img/{{array_keys(Config::get('languages'))[1]}}.svg" width="16"><b>Language 1</b></label>
-                                    <input type="text" name="lang1" class="input-tw w-full" style="min-width: 100%"  value="{{$product->product_detail->lang1 ?? ''}}">
-                                </td>
-                            </tr><tr>
-                                <td colspan="3">
-
-                                    <label for="lang2" class="form-label"><img src="/img/{{array_keys(Config::get('languages'))[2]}}.svg" width="16"><b>Language 2</b></label>
-                                    <input type="text" name="lang2" class="input-tw w-full" style="min-width: 100%" value="{{$product->product_detail->lang2 ?? ''}}">
-                                </td>
-                            </tr><tr>
-                                <td colspan="3">
-
-                                    <label for="lang3" class="form-label" ><img src="/img/{{array_keys(Config::get('languages'))[3]}}.svg" width="16"><b>Language 3</b></label>
-                                    <input type="text" name="lang3" class="input-tw w-full" style="min-width: 100%"  value="{{$product->product_detail->lang3 ?? ''}}">
-                                </td>
-                            </tr>
-                            <tr><td><h6 class="inline-flex bg-dark text-white mt-4">Save</h6></td><td><hr></td><td><hr></td></tr>
-
-                            <tr>
-                                <td colspan="3">
-                                    <button type="submit" class="btn-primary w-full max-w-md">SAVE</button>
-                                </td>
-                            </tr>
-
-                        </table>
-
-                        <div id="ProductPrice"></div>
-
-                    </form>
-
+@section('page_header')
+    <div class="flex flex-wrap items-center justify-between gap-4">
+        <div class="min-w-0">
+            <a href="{{ url('/products/index') }}"
+               class="text-sm text-slate-500 hover:text-slate-700">
+                &larr; {{ __('Volver a productos') }}
+            </a>
+            <h1 id="ProductName" class="mt-1 truncate text-2xl font-bold text-slate-900">
+                {{ $product->name ?: __('Producto') }}
+            </h1>
         </div>
+        <nav aria-label="{{ __('Secciones del producto') }}" class="hidden md:block">
+            <ul class="flex flex-wrap gap-1 text-xs">
+                @foreach ([
+                    'section-general'      => __('General'),
+                    'section-image'        => __('Imagen'),
+                    'section-pricing'      => __('Precio'),
+                    'section-extras'       => __('Extras'),
+                    'section-allergens'    => __('Alérgenos'),
+                    'section-translations' => __('Traducciones'),
+                ] as $anchor => $label)
+                    <li>
+                        <a href="#{{ $anchor }}"
+                           class="rounded-md border border-slate-200 bg-white px-2 py-1 text-slate-600 hover:bg-slate-50 hover:text-slate-900">
+                            {{ $label }}
+                        </a>
+                    </li>
+                @endforeach
+            </ul>
+        </nav>
     </div>
 @endsection
+
+@php
+    /** @var \App\Models\UnicentaModels\Product $product */
+    $detail = $product->product_detail;
+    $translationLanguages = $translationLanguages ?? [];
+@endphp
+
+@section('content')
+    <form id="product-edit-form"
+          data-product-id="{{ $product->id }}"
+          action="{{ route('products.update', $product->id) }}"
+          method="POST"
+          class="mx-auto max-w-5xl space-y-6"
+          novalidate>
+        <input type="hidden" name="redirects_to" value="{{ url()->previous() }}">
+        @method('PATCH')
+        @csrf
+
+        {{-- ============================================================
+             General
+         ============================================================ --}}
+        <fieldset id="section-general" class="card-tw">
+            <legend class="card-tw-header w-full">{{ __('General') }}</legend>
+            <div class="card-tw-body space-y-4">
+
+                <div>
+                    <label for="name" class="label-tw">{{ __('Nombre') }}</label>
+                    <input type="text" id="name" name="name" maxlength="255" required
+                           class="input-tw @error('name') border-red-400 @enderror"
+                           value="{{ old('name', $product->name) }}">
+                    @error('name')<p class="mt-1 text-sm text-red-600">{{ $message }}</p>@enderror
+                </div>
+
+                <div>
+                    <label for="description" class="label-tw">{{ __('Descripción') }}</label>
+                    <textarea id="description" name="description" rows="3"
+                              class="input-tw @error('description') border-red-400 @enderror">{{ old('description', $detail->description ?? '') }}</textarea>
+                    @error('description')<p class="mt-1 text-sm text-red-600">{{ $message }}</p>@enderror
+                </div>
+
+                <div>
+                    <label for="category" class="label-tw">{{ __('Categoría') }}</label>
+                    <select id="category" name="category" required
+                            class="input-tw @error('category') border-red-400 @enderror">
+                        @foreach ($categories as $category)
+                            <option value="{{ $category->id }}"
+                                {{ (string) old('category', $product->category) === (string) $category->id ? 'selected' : '' }}>
+                                {{ $category->name }}
+                            </option>
+                        @endforeach
+                    </select>
+                    @error('category')<p class="mt-1 text-sm text-red-600">{{ $message }}</p>@enderror
+                </div>
+
+                <div class="grid gap-4 sm:grid-cols-2">
+                    <div>
+                        <label for="printto" class="label-tw">{{ __('Impresora') }}</label>
+                        <input type="number" id="printto" name="printto" min="0" step="1" inputmode="numeric"
+                               class="input-tw @error('printto') border-red-400 @enderror"
+                               value="{{ old('printto', trim((string) ($product->printto ?? '1'))) }}">
+                        @error('printto')<p class="mt-1 text-sm text-red-600">{{ $message }}</p>@enderror
+                    </div>
+                    <div>
+                        <label for="taxcat" class="label-tw">{{ __('Tipo de IVA') }}</label>
+                        <input type="text" id="taxcat" name="taxcat" maxlength="10" required
+                               class="input-tw @error('taxcat') border-red-400 @enderror"
+                               value="{{ old('taxcat', $product->taxcat ?? '001') }}">
+                        @error('taxcat')<p class="mt-1 text-sm text-red-600">{{ $message }}</p>@enderror
+                    </div>
+                </div>
+            </div>
+        </fieldset>
+
+        {{-- ============================================================
+             Imagen
+         ============================================================ --}}
+        <fieldset id="section-image" class="card-tw">
+            <legend class="card-tw-header w-full">{{ __('Imagen') }}</legend>
+            <div class="card-tw-body">
+                <div class="grid items-center gap-6 sm:grid-cols-3">
+                    <div class="text-center sm:col-span-1">
+                        @if (! empty($hasImage))
+                            <img src="{{ url('/dbimage/' . $product->id . '.png') }}?v={{ time() }}"
+                                 alt="{{ $product->name }}"
+                                 class="mx-auto h-48 w-48 rounded-lg border border-slate-200 object-cover">
+                        @else
+                            <img src="{{ asset('img/no-image.png') }}"
+                                 alt="{{ __('Sin imagen') }}"
+                                 class="mx-auto h-48 w-48 rounded-lg border border-slate-200 object-cover opacity-60">
+                        @endif
+                    </div>
+                    <div class="sm:col-span-2">
+                        <p class="mb-3 text-sm text-slate-500">
+                            {{ __('Sube y recorta la imagen del producto. Cuadrada (1:1) recomendada.') }}
+                        </p>
+                        <a href="{{ url('/crop-image/' . $product->id) }}?redirects_to={{ urlencode(route('products.edit', $product->id)) }}"
+                           class="btn-secondary js-edit-image"
+                           data-product-id="{{ $product->id }}">
+                            <i class="fa fa-image mr-2"></i>{{ __('Editar imagen') }}
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </fieldset>
+
+        {{-- ============================================================
+             Datos del sistema (read-only)
+         ============================================================ --}}
+        <fieldset class="card-tw">
+            <legend class="card-tw-header w-full">{{ __('Datos del sistema') }}</legend>
+            <div class="card-tw-body grid gap-4 sm:grid-cols-2">
+                <div>
+                    <label for="reference" class="label-tw">{{ __('Referencia') }}</label>
+                    <input type="text" id="reference" name="reference" readonly
+                           class="input-tw bg-slate-100"
+                           value="{{ $product->reference }}">
+                </div>
+                <div>
+                    <label for="code" class="label-tw">{{ __('Código') }}</label>
+                    <input type="text" id="code" name="code" readonly
+                           class="input-tw bg-slate-100"
+                           value="{{ $product->code }}">
+                </div>
+            </div>
+        </fieldset>
+
+        {{-- ============================================================
+             Precio y stock
+         ============================================================ --}}
+        <fieldset id="section-pricing" class="card-tw">
+            <legend class="card-tw-header w-full">{{ __('Precio y stock') }}</legend>
+            <div class="card-tw-body grid gap-4 sm:grid-cols-3">
+                <div>
+                    <label for="stockunits" class="label-tw">{{ __('Unidades de stock') }}</label>
+                    <input type="number" id="stockunits" name="stockunits" step="0.001" inputmode="decimal" min="0"
+                           class="input-tw @error('stockunits') border-red-400 @enderror"
+                           value="{{ old('stockunits', $product->stockunits) }}">
+                    @error('stockunits')<p class="mt-1 text-sm text-red-600">{{ $message }}</p>@enderror
+                </div>
+                <div>
+                    <label for="pricebuy" class="label-tw">{{ __('Compra (sin IVA)') }}</label>
+                    <div class="relative">
+                        <input type="number" id="pricebuy" name="pricebuy" step="0.01" inputmode="decimal" min="0" required
+                               class="input-tw pr-8 @error('pricebuy') border-red-400 @enderror"
+                               value="{{ old('pricebuy', $product->pricebuy) }}">
+                        <span class="pointer-events-none absolute inset-y-0 right-2 flex items-center text-sm text-slate-400">€</span>
+                    </div>
+                    @error('pricebuy')<p class="mt-1 text-sm text-red-600">{{ $message }}</p>@enderror
+                </div>
+                <div>
+                    <label for="pricesell" class="label-tw">{{ __('Venta (con IVA)') }}</label>
+                    <div class="relative">
+                        <input type="number" id="pricesell" name="pricesell" step="0.01" inputmode="decimal" min="0" required
+                               class="input-tw pr-8 @error('pricesell') border-red-400 @enderror"
+                               value="{{ old('pricesell', number_format($product->price_sell_gross, 2, '.', '')) }}">
+                        <span class="pointer-events-none absolute inset-y-0 right-2 flex items-center text-sm text-slate-400">€</span>
+                    </div>
+                    @error('pricesell')<p class="mt-1 text-sm text-red-600">{{ $message }}</p>@enderror
+                </div>
+            </div>
+        </fieldset>
+
+        {{-- ============================================================
+             Extras / addons
+         ============================================================ --}}
+        <fieldset id="section-extras" class="card-tw">
+            <legend class="card-tw-header w-full">{{ __('Extras a añadir') }}</legend>
+            <div class="card-tw-body space-y-4">
+                <div class="grid items-end gap-4 sm:grid-cols-12">
+                    <div class="sm:col-span-5">
+                        <label for="category_addon" class="label-tw">{{ __('Categoría') }}</label>
+                        <select id="category_addon" name="category_addon" class="input-tw">
+                            @foreach ($categories as $categorie)
+                                <option value="{{ $categorie->id }}">{{ $categorie->name }}</option>
+                            @endforeach
+                        </select>
+                    </div>
+                    <div class="sm:col-span-5">
+                        <label for="products_list" class="label-tw">{{ __('Producto disponible') }}</label>
+                        <select id="products_list" name="products_list" class="input-tw">
+                            <option value="">— {{ __('Selecciona una categoría') }} —</option>
+                        </select>
+                    </div>
+                    <div class="sm:col-span-2">
+                        <button type="button" id="add-addon-btn" class="btn-secondary w-full">
+                            + {{ __('Añadir') }}
+                        </button>
+                    </div>
+                </div>
+
+                <hr class="border-slate-200">
+
+                <p class="text-xs text-slate-500">{{ __('Seleccionados') }}</p>
+                <ul class="flex flex-wrap gap-2" id="addon-chips">
+                    @forelse ($all_adons as $addon)
+                        <li>
+                            <span class="inline-flex items-center gap-2 rounded-full bg-slate-100 px-3 py-1 text-sm text-slate-700"
+                                  data-addon-id="{{ $addon->id }}">
+                                {{ $addon->name }}
+                                <button type="button"
+                                        class="remove-addon-btn text-slate-500 hover:text-red-600"
+                                        aria-label="{{ __('Eliminar') }} {{ $addon->name }}"
+                                        data-addon-id="{{ $addon->id }}">
+                                    &times;
+                                </button>
+                            </span>
+                        </li>
+                    @empty
+                        <li id="addon-empty" class="text-sm text-slate-500">
+                            {{ __('Sin extras seleccionados.') }}
+                        </li>
+                    @endforelse
+                </ul>
+            </div>
+        </fieldset>
+
+        {{-- ============================================================
+             Allergens
+         ============================================================ --}}
+        <fieldset id="section-allergens" class="card-tw">
+            <legend class="card-tw-header w-full">{{ __('Alérgenos') }}</legend>
+            <div class="card-tw-body space-y-3">
+                <p class="text-sm text-slate-500">
+                    {{ __('Pulsa un alérgeno para activarlo/desactivarlo. Se guarda al instante.') }}
+                </p>
+                <x-product.allergen-grid :product="$product" :detail="$detail" />
+            </div>
+        </fieldset>
+
+        {{-- ============================================================
+             Translations
+         ============================================================ --}}
+        @if (! empty($translationLanguages))
+            <fieldset id="section-translations" class="card-tw">
+                <legend class="card-tw-header w-full">{{ __('Traducciones') }}</legend>
+                <div class="card-tw-body space-y-4">
+                    @foreach (array_values($translationLanguages) as $idx => $langName)
+                        @php
+                            $langKey = array_keys($translationLanguages)[$idx] ?? null;
+                            $field = 'lang' . ($idx + 1);
+                            $flag = $langKey ? "/img/{$langKey}.svg" : null;
+                        @endphp
+                        <div>
+                            <label for="{{ $field }}" class="label-tw flex items-center gap-2">
+                                @if ($flag)
+                                    <img src="{{ $flag }}" alt="" width="16" class="inline-block">
+                                @endif
+                                <span>{{ $langName }}</span>
+                            </label>
+                            <input type="text" id="{{ $field }}" name="{{ $field }}"
+                                   class="input-tw"
+                                   value="{{ old($field, $detail->{$field} ?? '') }}">
+                        </div>
+                    @endforeach
+                </div>
+            </fieldset>
+        @endif
+
+        {{-- ============================================================
+             Sticky save bar
+         ============================================================ --}}
+        <div class="sticky bottom-0 -mx-4 flex items-center justify-between border-t border-slate-200 bg-white/95 px-4 py-3 backdrop-blur lg:-mx-6 lg:px-6">
+            <a href="{{ url('/products/index') }}" class="btn-secondary">
+                {{ __('Cancelar') }}
+            </a>
+            <div class="flex items-center gap-3">
+                <span id="save-toast" class="text-sm text-emerald-600" role="status" aria-live="polite"></span>
+                <button type="submit" class="btn-primary">{{ __('Guardar cambios') }}</button>
+            </div>
+        </div>
+    </form>
+@endsection
+
+@push('scripts')
+    <script>
+        (function ($) {
+            'use strict';
+
+            var productId = @json($product->id);
+
+            function showToast(msg, type) {
+                var $t = $('#save-toast');
+                $t.text(msg)
+                  .removeClass('text-emerald-600 text-red-600')
+                  .addClass(type === 'error' ? 'text-red-600' : 'text-emerald-600');
+                if ($t.data('hideTimer')) clearTimeout($t.data('hideTimer'));
+                $t.data('hideTimer', setTimeout(function () { $t.text(''); }, 2500));
+            }
+
+            $(function () {
+                // ---- Dirty form guard ----
+                var formDirty = false;
+                var $form = $('#product-edit-form');
+
+                $form.on('change input', ':input', function () { formDirty = true; });
+                $form.on('submit', function () { formDirty = false; });
+
+                $('.js-edit-image').on('click', function (e) {
+                    if (formDirty && !window.confirm(
+                        '{{ __('Hay cambios sin guardar que se perderán si continúas. ¿Quieres descartar los cambios?') }}'
+                    )) {
+                        e.preventDefault();
+                    }
+                });
+
+                // ---- Smooth scroll for section nav ----
+                $('a[href^="#section-"]').on('click', function (e) {
+                    var target = $(this.getAttribute('href'));
+                    if (target.length) {
+                        e.preventDefault();
+                        $('html, body').animate({ scrollTop: target.offset().top - 80 }, 250);
+                    }
+                });
+
+                // ---- Allergen toggles ----
+                $('#allergen-grid').on('click', '.toggleAlergen', function () {
+                    var $btn = $(this);
+                    var allergen = $btn.data('allergen');
+                    $btn.prop('disabled', true);
+                    $.ajax({
+                        url: '/product/alergen',
+                        type: 'POST',
+                        data: { product_id: productId, alergen_id: allergen },
+                        dataType: 'json'
+                    }).done(function (data) {
+                        var active = !!(data && data.active);
+                        $btn.attr('aria-pressed', active ? 'true' : 'false')
+                            .data('active', active ? 1 : 0)
+                            .toggleClass('border-emerald-500 bg-emerald-50 text-emerald-800', active)
+                            .toggleClass('border-slate-200 bg-white text-slate-600', !active);
+                        $btn.find('img').css('filter', active ? 'none' : 'grayscale(100%)');
+                        showToast(active
+                            ? '{{ __('Alérgeno activado') }}'
+                            : '{{ __('Alérgeno desactivado') }}');
+                    }).fail(function () {
+                        showToast('{{ __('No se pudo guardar el alérgeno') }}', 'error');
+                    }).always(function () {
+                        $btn.prop('disabled', false);
+                    });
+                });
+
+                // ---- Addon category change loads available products ----
+                function loadAddonProducts(catId) {
+                    if (!catId) return;
+                    $.ajax({
+                        url: '/products/list/' + catId,
+                        type: 'GET',
+                        dataType: 'json'
+                    }).done(function (data) {
+                        var $sel = $('#products_list').empty();
+                        $sel.append($('<option>', { value: '', text: '— {{ __('Selecciona un producto') }} —' }));
+                        $.each(data, function (_, item) {
+                            $sel.append($('<option>', { value: item.id, text: item.name }));
+                        });
+                    });
+                }
+
+                $('#category_addon').on('change', function () {
+                    loadAddonProducts($(this).val());
+                });
+                loadAddonProducts($('#category_addon').val());
+
+                // ---- Add a selected addon as a chip ----
+                $('#add-addon-btn').on('click', function () {
+                    var $sel = $('#products_list');
+                    var addonId = $sel.val();
+                    var addonName = $sel.find('option:selected').text();
+                    if (!addonId) {
+                        showToast('{{ __('Selecciona un producto') }}', 'error');
+                        return;
+                    }
+                    if ($('#addon-chips [data-addon-id="' + addonId + '"]').length) {
+                        showToast('{{ __('Ese extra ya está añadido') }}', 'error');
+                        return;
+                    }
+                    var price = window.prompt('{{ __('Precio del extra (con IVA, en €)') }}', '0');
+                    if (price === null) return;
+
+                    $.ajax({
+                        url: '/addOnProduct/add',
+                        type: 'POST',
+                        data: { product_id: productId, adon_product_id: addonId, price: price },
+                        dataType: 'json'
+                    }).done(function () {
+                        $('#addon-empty').remove();
+                        var $chip = $('<li></li>').append(
+                            $('<span class="inline-flex items-center gap-2 rounded-full bg-slate-100 px-3 py-1 text-sm text-slate-700"></span>')
+                                .attr('data-addon-id', addonId)
+                                .text(addonName + ' ')
+                                .append(
+                                    $('<button type="button" class="remove-addon-btn text-slate-500 hover:text-red-600">&times;</button>')
+                                        .attr('aria-label', '{{ __('Eliminar') }} ' + addonName)
+                                        .attr('data-addon-id', addonId)
+                                )
+                        );
+                        $('#addon-chips').append($chip);
+                        showToast('{{ __('Extra añadido') }}');
+                    }).fail(function () {
+                        showToast('{{ __('No se pudo añadir el extra') }}', 'error');
+                    });
+                });
+
+                // ---- Remove addon ----
+                $('#addon-chips').on('click', '.remove-addon-btn', function () {
+                    var addonId = $(this).data('addon-id');
+                    var $li = $(this).closest('li');
+                    $.ajax({
+                        url: '/addOnProduct/remove',
+                        type: 'POST',
+                        data: { product_id: productId, adon_product_id: addonId },
+                        dataType: 'json'
+                    }).done(function () {
+                        $li.remove();
+                        if ($('#addon-chips li').length === 0) {
+                            $('#addon-chips').append(
+                                '<li id="addon-empty" class="text-sm text-slate-500">{{ __('Sin extras seleccionados.') }}</li>'
+                            );
+                        }
+                        showToast('{{ __('Extra eliminado') }}');
+                    }).fail(function () {
+                        showToast('{{ __('No se pudo eliminar el extra') }}', 'error');
+                    });
+                });
+
+                // ---- Browser-level unload guard ----
+                window.addEventListener('beforeunload', function (e) {
+                    if (formDirty) {
+                        e.preventDefault();
+                        e.returnValue = '';
+                    }
+                });
+            });
+        })(jQuery);
+    </script>
+@endpush

--- a/resources/views/components/product/allergen-grid.blade.php
+++ b/resources/views/components/product/allergen-grid.blade.php
@@ -1,0 +1,45 @@
+@props([
+    'product',
+    'detail' => null,
+])
+
+@php
+    $detail = $detail ?? ($product->product_detail ?? null);
+    $allergens = [
+        'alerg_apio'        => ['file' => 'Apio.png',           'label' => 'Apio'],
+        'alerg_crustaceans' => ['file' => 'Crustaceans.png',    'label' => 'Marisco'],
+        'alerg_dairy'       => ['file' => 'DairyProducts.png',  'label' => 'Lácteo'],
+        'alerg_sulphites'   => ['file' => 'DioxideSulphites.png','label' => 'Sulfitos'],
+        'alerg_gluten'      => ['file' => 'Gluten.png',         'label' => 'Gluten'],
+        'alerg_lupins'      => ['file' => 'Lupins.png',         'label' => 'Altramuces'],
+        'alerg_mollusks'    => ['file' => 'Mollusks.png',       'label' => 'Moluscos'],
+        'alerg_egg'         => ['file' => 'Egg.png',            'label' => 'Huevo'],
+        'alerg_mustard'     => ['file' => 'Mustard.png',        'label' => 'Mostaza'],
+        'alerg_peanuts'     => ['file' => 'Peanuts.png',        'label' => 'Cacahuete'],
+        'alerg_peelfruits'  => ['file' => 'PeelFruits.png',     'label' => 'Frutos Secos'],
+        'alerg_sesame'      => ['file' => 'SesameGrains.png',   'label' => 'Sésamo'],
+        'alerg_soy'         => ['file' => 'Soy.png',            'label' => 'Soja'],
+        'alerg_fish'        => ['file' => 'Fish.png',           'label' => 'Pescado'],
+    ];
+@endphp
+
+<div id="allergen-grid" class="flex flex-wrap gap-2">
+    @foreach ($allergens as $key => $a)
+        @php $active = $detail && $detail->{$key}; @endphp
+        <button type="button"
+                id="{{ $key }}"
+                class="toggleAlergen flex w-20 flex-col items-center rounded-lg border p-2 text-xs transition focus:outline-none focus:ring-2 focus:ring-brand
+                       {{ $active
+                           ? 'border-emerald-500 bg-emerald-50 text-emerald-800'
+                           : 'border-slate-200 bg-white text-slate-600' }}"
+                aria-label="{{ $a['label'] }}"
+                aria-pressed="{{ $active ? 'true' : 'false' }}"
+                data-active="{{ $active ? '1' : '0' }}"
+                data-allergen="{{ $key }}"
+                title="{{ $a['label'] }}">
+            <img src="/img/allergens/{{ $a['file'] }}" alt="" width="32" height="32"
+                 style="filter: {{ $active ? 'none' : 'grayscale(100%)' }};">
+            <span class="mt-1 block">{{ $a['label'] }}</span>
+        </button>
+    @endforeach
+</div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Ports the four product-edit PRs (#9, #10, #11, #12 — originally branched off `master`) onto `main`, as a single PR.

## Why a single PR rather than the four

I tried a normal merge first. `git merge` refused with `fatal: refusing to merge unrelated histories` because **`main` and `master` share no common ancestor** — `main` was started fresh ("first commit new version", `0cfd24d`) and is in the middle of a Tailwind/Vite/Laravel‑9 redesign while `master` is on Bootstrap 4 / Laravel 8.

Cherry-picking the four commits also conflicted on every view: my work assumed `layouts.reg` + Bootstrap 4 (`card`, `form-control`, `input-group`), while `main` already moved `edit.blade.php` and `crop_image.blade.php` to `layouts.admin` + Tailwind utilities (`card-tw`, `input-tw`, `btn-primary`).

So this PR ports the same logic onto main:
- The PHP layer (controller, FormRequests, Policy, model accessor) drops in cleanly.
- The Blade views were re-written on top of `layouts.admin` / Tailwind utilities to match main's design system.

## What's in this PR

### Backend (identical to PR #12 on master)
- `app/Models/ProductDetail.php` — add `alerg_apio` / `alerg_soy` / `alerg_fish` to `$fillable`; new `ALLERGEN_KEYS` allow-list constant.
- `app/Models/UnicentaModels/Product.php` — `DEFAULT_VAT_FACTOR` constant + `price_sell_gross` accessor & mutator (replaces the magic `* 1.1` / `/ 1.1` previously scattered in the controller).
- `app/Http/Requests/{Store,Update}ProductRequest`, `AddOnProductRequest`, `RemoveAddOnProductRequest`, `ToggleAllergenRequest` — typed FormRequests own validation, mass-assignment whitelist and price normalisation; `authorize()` against `User::isManager()`.
- `app/Policies/ProductPolicy` (+ `AuthServiceProvider` registration) — explicit `viewAny` / `view` / `create` / `update` / `delete`; the controller now calls `$this->authorize(...)`.
- `app/Http/Controllers/ProductController.php` — rewritten to use the FormRequests; eager-load `product_detail`; addons N+1 replaced with single `whereIn`; `printto` trimmed; `pricesell` written via the new mutator; `redirects_to` validated through `safeRedirect()` (open-redirect fix).

### Views (Tailwind port)
- `resources/views/admin/products/edit.blade.php` — rewritten on Tailwind with semantic `<fieldset>` / `<legend>` sections (General, Imagen, Datos del sistema, Precio y stock, Extras a añadir, Alérgenos, Traducciones), `€` input addons, sticky save bar, section pill nav with smooth scroll, addon chips UX (Categoría → Producto disponible → "+ Añadir" → removable chips), unsaved-changes guard on "Editar imagen" and `beforeunload`, toast feedback for AJAX saves.
- `resources/views/components/product/allergen-grid.blade.php` (new) — reusable Tailwind-styled allergen grid with `aria-pressed` buttons and `grayscale` filter for inactive icons.
- `resources/views/admin/products/crop_image.blade.php` — honour `?redirects_to=…` so `/crop-image` returns the user to the page they came from.

## Testing

End-to-end smoke against a local Laravel 9 / PHP 8.4 install of `main` (composer + npm + `vite build`, MariaDB seeded with manager user + sample categories/products):

- ✅ `GET /products/prod-cana/edit` → HTTP 200, ~42 KB; 52 Tailwind utility class hits in the markup; 14 allergen buttons rendered through the new component.
- ✅ `PATCH /products/prod-cana` with `pricesell=2.20` → DB stores `pricesell=2.0000` (= 2.20 / 1.1 via the new mutator); `printto` saved without trailing space; `taxcat` preserved.
- ✅ `POST /product/alergen` with valid key → `{status:true, active:true}`; with `alergen_id=description` → `422` (allow-list enforced).
- ✅ `POST /addOnProduct/add` with `price=2,99` → row inserted with `price=2.99` (comma-decimal normalised by `priceAsFloat()`); bogus `adon_product_id` → `422`.
- ✅ `POST /addOnProduct/remove` → 200 and row deleted.
- ✅ `redirects_to=https://evil.example.com/` → 302 to the edit page (open-redirect blocked by `safeRedirect`).
- ✅ `php -l` clean on every PHP file; `php artisan view:cache` compiles all Blade including the new component.

[Rebuilt product edit page on main (Tailwind layout, sticky save bar, section nav)](https://cursor.com/agents/bc-79376bd7-036d-4d25-bc99-57d7e5b38fb9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_edit_page_on_main_real.png)

## Heads-up

I did **not** modify `deploy.php`, `deploy.yaml`, `composer.json`, `composer.lock` or `package-lock.json`. The deploy config still points at `https://github.com/scimsoft/mobiletender.git` while we are working in `mobiletender-old`; if you intend to deploy this to `playaalta-test` (or any other host) via Deployer, that repo URL also needs updating (or this branch needs to land on `mobiletender:main` too) — see my previous reply for the full list.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-79376bd7-036d-4d25-bc99-57d7e5b38fb9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-79376bd7-036d-4d25-bc99-57d7e5b38fb9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

