### PR TITLE
Add Ofertas (offers) feature with virtual-table semantics

### DIFF
--- a/app/Http/Controllers/OfferController.php
+++ b/app/Http/Controllers/OfferController.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Offer;
+use App\Models\OfferProduct;
+use App\Models\UnicentaModels\Category;
+use App\Models\UnicentaModels\Product;
+use App\Traits\OfferTrait;
+use App\Traits\SharedTicketTrait;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Session;
+use Illuminate\Support\Str;
+
+class OfferController extends Controller
+{
+    use OfferTrait;
+
+    public function index()
+    {
+        $offers = Offer::with('offerProducts')
+            ->orderBy('sort_order')
+            ->orderBy('name')
+            ->get();
+
+        return view('admin.offers.index', compact('offers'));
+    }
+
+    public function create()
+    {
+        $categories = Category::orderByRaw('CONVERT(catorder, SIGNED)')->get();
+        $products = Product::orderBy('name')->get();
+        return view('admin.offers.create', compact('categories', 'products'));
+    }
+
+    public function store(Request $request)
+    {
+        $request->validate([
+            'name' => 'required',
+            'final_price' => 'required',
+        ]);
+
+        $offer = new Offer([
+            'id' => Str::uuid()->toString(),
+            'name' => $request->input('name'),
+            'final_price' => $request->input('final_price'),
+            'active' => $request->has('active'),
+            'sort_order' => (int) $request->input('sort_order', 0),
+        ]);
+        $offer->save();
+
+        $this->syncOfferProducts($offer, $request);
+
+        return redirect()->route('offers.edit', $offer->id)
+            ->with('success', 'Oferta creada correctamente.');
+    }
+
+    public function edit($id)
+    {
+        $offer = Offer::with('offerProducts')->findOrFail($id);
+        $categories = Category::orderByRaw('CONVERT(catorder, SIGNED)')->get();
+        $products = Product::orderBy('name')->get();
+
+        $productsSubtotal = $this->getOfferProductsSubtotalSell($offer) * 1.1;
+
+        return view('admin.offers.edit', compact('offer', 'categories', 'products', 'productsSubtotal'));
+    }
+
+    public function update(Request $request, $id)
+    {
+        $request->validate([
+            'name' => 'required',
+            'final_price' => 'required',
+        ]);
+
+        $offer = Offer::findOrFail($id);
+        $offer->name = $request->input('name');
+        $offer->final_price = $request->input('final_price');
+        $offer->active = $request->has('active');
+        $offer->sort_order = (int) $request->input('sort_order', 0);
+        $offer->save();
+
+        $this->syncOfferProducts($offer, $request);
+
+        return redirect()->route('offers.edit', $offer->id)
+            ->with('success', 'Oferta actualizada correctamente.');
+    }
+
+    public function destroy($id)
+    {
+        $offer = Offer::findOrFail($id);
+        OfferProduct::where('offer_id', $offer->id)->delete();
+        $offer->delete();
+
+        return redirect()->route('offers.index')
+            ->with('success', 'Oferta borrada.');
+    }
+
+    public function showOffersForOrder()
+    {
+        $this->checkForSessionTicketId();
+
+        $offers = Offer::with('offerProducts')
+            ->where('active', true)
+            ->orderBy('sort_order')
+            ->orderBy('name')
+            ->get();
+
+        $totalBasketPrice = $this->getSumTicketLines(Session::get('ticketID'));
+
+        return view('order.offers', compact('offers', 'totalBasketPrice'));
+    }
+
+    private function checkForSessionTicketId()
+    {
+        $ticketID = Session::get('ticketID');
+        if (is_null($ticketID) || $this->hasTicket($ticketID) < 1) {
+            $ticket = $this->createEmptyTicket();
+            $newTicketID = Str::uuid()->toString();
+            $this->saveEmptyTicket($ticket, $newTicketID);
+            Session::put('ticketID', $newTicketID);
+            Session::forget('tableNumber');
+        }
+    }
+
+    public function addOffer($id)
+    {
+        $offer = Offer::with('offerProducts')->findOrFail($id);
+        $tableNumber = Session::get('ticketID');
+
+        if (empty($tableNumber)) {
+            return redirect()->route('order')
+                ->with('error', 'No hay mesa o ticket activo.');
+        }
+
+        $this->addOfferToTicket($offer, $tableNumber);
+
+        return redirect()->route('basket')
+            ->with('status', 'Oferta "' . $offer->name . '" añadida al ticket.');
+    }
+
+    private function syncOfferProducts(Offer $offer, Request $request)
+    {
+        OfferProduct::where('offer_id', $offer->id)->delete();
+
+        $productIds = (array) $request->input('product_id', []);
+        $quantities = (array) $request->input('quantity', []);
+
+        foreach ($productIds as $i => $productId) {
+            if (empty($productId)) {
+                continue;
+            }
+            $qty = isset($quantities[$i]) ? max(1, (int) $quantities[$i]) : 1;
+            OfferProduct::create([
+                'offer_id' => $offer->id,
+                'product_id' => $productId,
+                'quantity' => $qty,
+            ]);
+        }
+    }
+}

--- a/app/Models/Offer.php
+++ b/app/Models/Offer.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Offer extends Model
+{
+    protected $table = 'offers';
+    protected $primaryKey = 'id';
+    protected $keyType = 'string';
+    public $incrementing = false;
+
+    protected $fillable = [
+        'id', 'name', 'final_price', 'active', 'sort_order',
+    ];
+
+    protected $casts = [
+        'active' => 'boolean',
+        'final_price' => 'float',
+        'sort_order' => 'integer',
+    ];
+
+    public function setFinalPriceAttribute($value)
+    {
+        $this->attributes['final_price'] = is_string($value)
+            ? str_replace(',', '.', $value)
+            : $value;
+    }
+
+    public function offerProducts()
+    {
+        return $this->hasMany(OfferProduct::class, 'offer_id', 'id');
+    }
+}

--- a/app/Models/OfferProduct.php
+++ b/app/Models/OfferProduct.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Models;
+
+use App\Models\UnicentaModels\Product;
+use Illuminate\Database\Eloquent\Model;
+
+class OfferProduct extends Model
+{
+    protected $table = 'offer_products';
+    public $timestamps = false;
+
+    protected $fillable = [
+        'offer_id', 'product_id', 'quantity',
+    ];
+
+    protected $casts = [
+        'quantity' => 'integer',
+    ];
+
+    public function offer()
+    {
+        return $this->belongsTo(Offer::class, 'offer_id', 'id');
+    }
+
+    public function product()
+    {
+        return $this->belongsTo(Product::class, 'product_id', 'id');
+    }
+}

--- a/app/Traits/OfferTrait.php
+++ b/app/Traits/OfferTrait.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace App\Traits;
+
+use App\Models\Offer;
+use App\Models\UnicentaModels\Product;
+use App\Models\UnicentaModels\SharedTicketLines;
+use App\Models\UnicentaModels\SharedTicketProduct;
+use App\Models\UnicentaModels\SharedTicketUser;
+use Illuminate\Support\Facades\DB;
+
+trait OfferTrait
+{
+    use SharedTicketTrait;
+
+    public function buildVirtualOfferTicket(Offer $offer)
+    {
+        $sharedTicket = $this->createEmptyTicket();
+        $sharedTicket->m_User = new SharedTicketUser();
+
+        $lineNumber = 0;
+        foreach ($offer->offerProducts as $offerProduct) {
+            $product = Product::find($offerProduct->product_id);
+            if (!$product) {
+                continue;
+            }
+            $qty = max(1, (int) $offerProduct->quantity);
+            for ($i = 0; $i < $qty; $i++) {
+                $sharedTicketProduct = new SharedTicketProduct(
+                    $product->reference,
+                    $product->name,
+                    $product->code,
+                    $product->category,
+                    $product->printto,
+                    $product->pricesell,
+                    $product->id
+                );
+                $sharedTicket->m_aLines[] = new SharedTicketLines(
+                    $sharedTicket->m_sId,
+                    $sharedTicketProduct,
+                    $lineNumber++
+                );
+            }
+        }
+
+        return $sharedTicket;
+    }
+
+    public function getOfferProductsSubtotalSell(Offer $offer)
+    {
+        $sum = 0.0;
+        foreach ($offer->offerProducts as $offerProduct) {
+            $product = Product::find($offerProduct->product_id);
+            if (!$product) {
+                continue;
+            }
+            $qty = max(1, (int) $offerProduct->quantity);
+            $sum += ((float) $product->pricesell) * $qty;
+        }
+        return $sum;
+    }
+
+    public function addOfferToTicket(Offer $offer, $tableNumber)
+    {
+        if (!$this->hasTicket($tableNumber)) {
+            $this->saveEmptyTicket($this->createEmptyTicket(), $tableNumber);
+        }
+
+        $virtualTicket = $this->buildVirtualOfferTicket($offer);
+        $virtualLines = $virtualTicket->m_aLines;
+
+        if (empty($virtualLines)) {
+            return;
+        }
+
+        $productsSell = 0.0;
+        foreach ($virtualLines as $line) {
+            $productsSell += (float) $line->price;
+        }
+
+        $finalPriceWithTax = (float) $offer->final_price;
+        $targetSell = $finalPriceWithTax / 1.1;
+        $adjustmentSell = $targetSell - $productsSell;
+
+        $sharedTicket = $this->getTicket($tableNumber);
+        $sharedTicket->m_User = new SharedTicketUser();
+        $existingCount = count($sharedTicket->m_aLines);
+
+        foreach ($virtualLines as $vline) {
+            $vline->m_sTicket = $sharedTicket->m_sId;
+            $vline->setLineNumber($existingCount++);
+            $sharedTicket->m_aLines[] = $vline;
+        }
+
+        if (abs($adjustmentSell) > 0.0001) {
+            $adjustmentProduct = new SharedTicketProduct(
+                'OFFER-' . $offer->id,
+                'Ajuste oferta: ' . $offer->name,
+                'OFFER-' . $offer->id,
+                null,
+                null,
+                $adjustmentSell,
+                'offer-' . $offer->id
+            );
+            $sharedTicket->m_aLines[] = new SharedTicketLines(
+                $sharedTicket->m_sId,
+                $adjustmentProduct,
+                $existingCount++
+            );
+        }
+
+        $this->updateOpenTable($sharedTicket, $tableNumber);
+    }
+}

--- a/database/migrations/2026_04_28_120000_create_offers_table.php
+++ b/database/migrations/2026_04_28_120000_create_offers_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateOffersTable extends Migration
+{
+    public function up()
+    {
+        Schema::create('offers', function (Blueprint $table) {
+            $table->string('id')->primary();
+            $table->string('name');
+            $table->double('final_price')->default(0);
+            $table->boolean('active')->default(true);
+            $table->integer('sort_order')->default(0);
+            $table->timestamps();
+        });
+
+        Schema::create('offer_products', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('offer_id');
+            $table->string('product_id');
+            $table->integer('quantity')->default(1);
+            $table->index('offer_id');
+            $table->index('product_id');
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('offer_products');
+        Schema::dropIfExists('offers');
+    }
+}

--- a/resources/views/admin/admin.blade.php
+++ b/resources/views/admin/admin.blade.php
@@ -117,6 +117,13 @@
                             <span class="mt-4 inline-flex text-sm font-medium text-brand-dark group-hover:underline">{{ __('Abrir') }} →</span>
                         </div>
                     </a>
+                    <a href="{{ url('/offers') }}" class="card-tw group transition hover:shadow-md">
+                        <div class="card-tw-body">
+                            <p class="font-semibold text-slate-900">{{ __('Ofertas') }}</p>
+                            <p class="mt-1 text-sm text-slate-600">{{ __('Crear paquetes de productos a precio fijo') }}</p>
+                            <span class="mt-4 inline-flex text-sm font-medium text-brand-dark group-hover:underline">{{ __('Abrir') }} →</span>
+                        </div>
+                    </a>
                     <a href="{{ url('/stats') }}" class="card-tw group transition hover:shadow-md">
                         <div class="card-tw-body">
                             <p class="font-semibold text-slate-900">{{ __('Stats') }}</p>

--- a/resources/views/admin/offers/_form.blade.php
+++ b/resources/views/admin/offers/_form.blade.php
@@ -1,0 +1,132 @@
+<div class="row">
+    <div class="col-md-6">
+        <label class="form-label"><b>Nombre</b></label>
+        <input name="name" class="form-control" type="text"
+               value="{{ old('name', $offer->name ?? '') }}" required>
+    </div>
+    <div class="col-md-3">
+        <label class="form-label"><b>Precio final (con IVA)</b></label>
+        <input name="final_price" class="form-control" type="text"
+               value="{{ old('final_price', isset($offer) ? number_format($offer->final_price, 2, '.', '') : '') }}"
+               required>
+    </div>
+    <div class="col-md-2">
+        <label class="form-label"><b>Orden</b></label>
+        <input name="sort_order" class="form-control" type="number"
+               value="{{ old('sort_order', $offer->sort_order ?? 0) }}">
+    </div>
+    <div class="col-md-1 d-flex align-items-end">
+        <div class="form-check">
+            <input class="form-check-input" type="checkbox" name="active"
+                   id="active"
+                   {{ (isset($offer) ? $offer->active : true) ? 'checked' : '' }}>
+            <label class="form-check-label" for="active"><b>Activa</b></label>
+        </div>
+    </div>
+</div>
+
+<hr>
+
+<h4>Productos en la oferta</h4>
+<p class="text-muted">
+    Esto es la "mesa virtual" de la oferta. Añade los productos y cantidades.
+    Cuando un cliente pida la oferta, estos productos se moverán a su mesa
+    con un ajuste para que el total sume el precio final indicado.
+</p>
+
+<table class="table table-bordered" id="offer-products-table">
+    <thead>
+        <tr>
+            <th width="60%">Producto</th>
+            <th width="20%">Cantidad</th>
+            <th width="20%">Quitar</th>
+        </tr>
+    </thead>
+    <tbody>
+    @php
+        $existingLines = isset($offer)
+            ? $offer->offerProducts->map(fn ($op) => ['product_id' => $op->product_id, 'quantity' => $op->quantity])->toArray()
+            : [];
+    @endphp
+    @forelse($existingLines as $line)
+        <tr class="offer-product-row">
+            <td>
+                <select name="product_id[]" class="form-control">
+                    <option value="">-- selecciona producto --</option>
+                    @foreach($products as $product)
+                        <option value="{{ $product->id }}"
+                            {{ $line['product_id'] == $product->id ? 'selected' : '' }}>
+                            {{ $product->name }} ({{ number_format($product->pricesell * 1.1, 2) }}€)
+                        </option>
+                    @endforeach
+                </select>
+            </td>
+            <td>
+                <input type="number" name="quantity[]" min="1"
+                       value="{{ $line['quantity'] }}" class="form-control">
+            </td>
+            <td>
+                <button type="button" class="btn btn-tab remove-offer-row">Quitar</button>
+            </td>
+        </tr>
+    @empty
+        <tr class="offer-product-row">
+            <td>
+                <select name="product_id[]" class="form-control">
+                    <option value="">-- selecciona producto --</option>
+                    @foreach($products as $product)
+                        <option value="{{ $product->id }}">
+                            {{ $product->name }} ({{ number_format($product->pricesell * 1.1, 2) }}€)
+                        </option>
+                    @endforeach
+                </select>
+            </td>
+            <td>
+                <input type="number" name="quantity[]" min="1" value="1" class="form-control">
+            </td>
+            <td>
+                <button type="button" class="btn btn-tab remove-offer-row">Quitar</button>
+            </td>
+        </tr>
+    @endforelse
+    </tbody>
+</table>
+
+<button type="button" id="add-offer-row" class="btn btn-tab">+ Añadir producto</button>
+
+@isset($productsSubtotal)
+    <p class="mt-3">
+        <b>Suma de productos (PVP):</b> {{ number_format($productsSubtotal, 2) }}€<br>
+        <b>Precio final oferta:</b> {{ number_format((float) $offer->final_price, 2) }}€<br>
+        <b>Descuento aplicado:</b>
+        {{ number_format($productsSubtotal - (float) $offer->final_price, 2) }}€
+    </p>
+@endisset
+
+<div class="text-center mt-3">
+    <button type="submit" class="btn btn-primary">Guardar</button>
+    <a href="{{ route('offers.index') }}" class="btn btn-tab">Cancelar</a>
+</div>
+
+@section('scripts')
+<script>
+    jQuery(document).ready(function () {
+        $('#add-offer-row').on('click', function () {
+            var $template = $('#offer-products-table tbody tr').first().clone();
+            $template.find('select').val('');
+            $template.find('input[type="number"]').val(1);
+            $('#offer-products-table tbody').append($template);
+        });
+
+        $('#offer-products-table').on('click', '.remove-offer-row', function () {
+            var $rows = $('#offer-products-table tbody tr');
+            if ($rows.length > 1) {
+                $(this).closest('tr').remove();
+            } else {
+                $(this).closest('tr').find('select').val('');
+                $(this).closest('tr').find('input[type="number"]').val(1);
+            }
+        });
+    });
+</script>
+@stop

--- a/resources/views/admin/offers/create.blade.php
+++ b/resources/views/admin/offers/create.blade.php
@@ -1,0 +1,24 @@
+@extends('layouts.reg')
+
+@section('content')
+    <div class="container">
+        <div class="card">
+            <div class="card-header"><h3>Nueva Oferta</h3></div>
+            <div class="card-body">
+                @if ($errors->any())
+                    <div class="alert alert-danger">
+                        <ul class="mb-0">
+                            @foreach ($errors->all() as $error)
+                                <li>{{ $error }}</li>
+                            @endforeach
+                        </ul>
+                    </div>
+                @endif
+                <form action="{{ route('offers.store') }}" method="POST">
+                    @csrf
+                    @include('admin.offers._form')
+                </form>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/admin/offers/edit.blade.php
+++ b/resources/views/admin/offers/edit.blade.php
@@ -1,0 +1,28 @@
+@extends('layouts.reg')
+
+@section('content')
+    <div class="container">
+        <div class="card">
+            <div class="card-header"><h3>Editar Oferta</h3></div>
+            <div class="card-body">
+                @if ($message = Session::get('success'))
+                    <div class="alert alert-success"><p>{{ $message }}</p></div>
+                @endif
+                @if ($errors->any())
+                    <div class="alert alert-danger">
+                        <ul class="mb-0">
+                            @foreach ($errors->all() as $error)
+                                <li>{{ $error }}</li>
+                            @endforeach
+                        </ul>
+                    </div>
+                @endif
+                <form action="{{ route('offers.update', $offer->id) }}" method="POST">
+                    @csrf
+                    @method('PUT')
+                    @include('admin.offers._form')
+                </form>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/admin/offers/index.blade.php
+++ b/resources/views/admin/offers/index.blade.php
@@ -1,0 +1,66 @@
+@extends('layouts.reg')
+
+@section('content')
+    <div class="container">
+        <div class="row">
+            <div class="col-lg-12 margin-tb">
+                <div class="pull-left"><h2>Ofertas</h2></div>
+            </div>
+        </div>
+
+        @if ($message = Session::get('success'))
+            <div class="alert alert-success"><p>{{ $message }}</p></div>
+        @endif
+        @if ($message = Session::get('error'))
+            <div class="alert alert-danger"><p>{{ $message }}</p></div>
+        @endif
+
+        <div class="float-right mb-2">
+            <a class="btn btn-tab" href="{{ route('offers.create') }}">Nueva oferta</a>
+        </div>
+
+        <table class="table table-bordered">
+            <thead>
+                <tr>
+                    <th>Activa</th>
+                    <th>Orden</th>
+                    <th>Nombre</th>
+                    <th>Productos</th>
+                    <th>Precio Final</th>
+                    <th>Acciones</th>
+                </tr>
+            </thead>
+            <tbody>
+            @forelse($offers as $offer)
+                <tr>
+                    <td>{{ $offer->active ? 'Si' : 'No' }}</td>
+                    <td>{{ $offer->sort_order }}</td>
+                    <td>{{ $offer->name }}</td>
+                    <td>
+                        @foreach($offer->offerProducts as $op)
+                            <span class="badge badge-info">
+                                {{ $op->quantity }}x
+                                {{ optional($op->product)->name ?? $op->product_id }}
+                            </span>
+                        @endforeach
+                    </td>
+                    <td>@money($offer->final_price)</td>
+                    <td>
+                        <a href="{{ route('offers.edit', $offer->id) }}" class="btn btn-tab">Editar</a>
+                        <form action="{{ route('offers.destroy', $offer->id) }}" method="POST" style="display:inline">
+                            @csrf
+                            @method('DELETE')
+                            <button type="submit" class="btn btn-tab"
+                                    onclick="return confirm('¿Borrar la oferta?');">Borrar</button>
+                        </form>
+                    </td>
+                </tr>
+            @empty
+                <tr>
+                    <td colspan="6" class="text-center">No hay ofertas. Crea una nueva.</td>
+                </tr>
+            @endforelse
+            </tbody>
+        </table>
+    </div>
+@endsection

--- a/resources/views/order/offers.blade.php
+++ b/resources/views/order/offers.blade.php
@@ -1,0 +1,52 @@
+@extends('layouts.app')
+
+@section('content')
+    <div class="container">
+        <div class="row justify-content-center">
+            <div class="card">
+                <div class="card-header text-center"><h4>Ofertas</h4></div>
+                <div class="card-body text-center">
+                    @if (session('status'))
+                        <div class="alert alert-success">{{ session('status') }}</div>
+                    @endif
+                    @if (session('error'))
+                        <div class="alert alert-danger">{{ session('error') }}</div>
+                    @endif
+
+                    @if($offers->isEmpty())
+                        <p class="text-muted">No hay ofertas disponibles ahora mismo.</p>
+                        <a href="/order" class="btn btn-tab">Volver al menú</a>
+                    @else
+                        <table id="offers-table" class="table middleTable">
+                            <tbody>
+                            @foreach($offers as $offer)
+                                <tr class="productrow">
+                                    <td class="align-middle text-left">
+                                        <h5>{{ $offer->name }}</h5>
+                                        <small class="text-muted">
+                                            @foreach($offer->offerProducts as $op)
+                                                {{ $op->quantity }}x
+                                                {{ optional($op->product)->name ?? '?' }}@if(!$loop->last), @endif
+                                            @endforeach
+                                        </small>
+                                    </td>
+                                    <td class="nowrapcol align-middle">
+                                        <b>@money($offer->final_price)</b>
+                                    </td>
+                                    <td class="align-middle">
+                                        <a href="{{ route('order.addoffer', $offer->id) }}"
+                                           class="btn btn-tab btn-add">
+                                            {{ __('Añadir') }}&nbsp;<img src="/img/cart.svg" width="16">
+                                        </a>
+                                    </td>
+                                </tr>
+                            @endforeach
+                            </tbody>
+                        </table>
+                        <a href="/order" class="btn btn-tab m-1">Volver al menú</a>
+                    @endif
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/order/order.blade.php
+++ b/resources/views/order/order.blade.php
@@ -31,6 +31,13 @@
                 @endforeach
             </nav>
 
+            <div class="mb-4 flex justify-end">
+                <a href="{{ route('order.offers') }}"
+                   class="inline-flex items-center gap-2 rounded-lg bg-amber-400 px-4 py-2 text-sm font-semibold text-amber-900 shadow-sm transition hover:bg-amber-300">
+                    {{ __('Ofertas') }}
+                </a>
+            </div>
+
             @if ($productRows->isEmpty())
                 <div class="py-12 text-center text-slate-500" role="status">
                     {{ __('No hay productos en esta categoría.') }}

--- a/routes/web.php
+++ b/routes/web.php
@@ -10,6 +10,7 @@ use App\Http\Controllers\Admin\AdminStatsController;
 use App\Http\Controllers\Admin\AdminStockController;
 use App\Http\Controllers\CategoryController;
 use App\Http\Controllers\BasketController;
+use App\Http\Controllers\OfferController;
 use App\Http\Controllers\OrderController;
 use App\Http\Controllers\PayPalController;
 use App\Http\Controllers\ProductController;
@@ -120,6 +121,16 @@ Route::group(['middleware' => ['web']], function () {
 
     Route::post('/categories/setparent',[CategoryController::class,'setParentId'])->middleware('is_manager');
     Route::post('/categories/toggleactive',[CategoryController::class,'toggleActive'])->middleware('is_manager');
+
+    Route::get('/offers', [OfferController::class, 'index'])->middleware('is_manager')->name('offers.index');
+    Route::get('/offers/create', [OfferController::class, 'create'])->middleware('is_manager')->name('offers.create');
+    Route::post('/offers', [OfferController::class, 'store'])->middleware('is_manager')->name('offers.store');
+    Route::get('/offers/{id}/edit', [OfferController::class, 'edit'])->middleware('is_manager')->name('offers.edit');
+    Route::put('/offers/{id}', [OfferController::class, 'update'])->middleware('is_manager')->name('offers.update');
+    Route::delete('/offers/{id}', [OfferController::class, 'destroy'])->middleware('is_manager')->name('offers.destroy');
+
+    Route::get('/order/offers', [OfferController::class, 'showOffersForOrder'])->name('order.offers');
+    Route::get('/order/addoffer/{id}', [OfferController::class, 'addOffer'])->name('order.addoffer');
 
     Route::get('/payments/{id}',[AdminPaymentController::class,'pay'])->middleware('is_manager');
     //Route::get('/payed/{id}/{mode}',[AdminPaymentController::class,'payed'])->middleware('is_manager');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds a new "Ofertas" (offers) module to the POS. Each offer behaves like a small virtual table: an admin configures a bundle of products and gives the bundle a single fixed final price. When a customer/waiter asks for an offer, the bundle's products are appended to the active ticket together with an automatic adjustment line so the bundle totals exactly the configured price — just like moving a virtual table onto the customer's table.

> Re-targeted onto `main` (replacing #13 which was opened against `master`).

## How it works

- **Admin → Ofertas** (card under the ADMIN section of `/admin`):
  - List, create, edit, delete offers.
  - Each offer has: name, final price (with IVA), active flag, sort order, and a list of `(product, quantity)` rows.
- **Customer/waiter → Ofertas button** on `/order`:
  - Lists all active offers with their products and final price.
  - Clicking *Añadir* adds every product line of the offer to the current ticket plus an `Ajuste oferta: <name>` line so the bundle nets exactly the configured final price (positive or negative adjustment supported).
- The original "virtual table" is rebuilt on the fly each time, so no stale `sharedticket` row remains — equivalent to the table-move + clean behavior already used in `SharedTicketTrait::moveTable`.

## Files

- `database/migrations/2026_04_28_120000_create_offers_table.php` — new `offers` and `offer_products` tables.
- `app/Models/Offer.php`, `app/Models/OfferProduct.php` — Eloquent models.
- `app/Traits/OfferTrait.php` — builds the virtual ticket and merges it into the target table, computing the price adjustment vs. the configured final price (using the codebase's existing 1.10 IVA convention).
- `app/Http/Controllers/OfferController.php` — admin CRUD + customer `addOffer`.
- `routes/web.php` — admin routes (`is_manager`-protected) and `/order/offers`, `/order/addoffer/{id}`.
- `resources/views/admin/offers/{index,create,edit,_form}.blade.php` — admin UI.
- `resources/views/order/offers.blade.php` — customer-facing offers list.
- Links added on the Tailwind admin dashboard (`Ofertas` card) and on `/order` (Ofertas button).

## Testing

- ✅ `php artisan migrate --force` — new migration runs cleanly.
- ✅ `php artisan route:list | grep offer` — all 8 expected routes wired.
- ✅ HTTP integration test as logged-in admin on the rebased branch:
  - `GET /admin`, `/offers`, `/offers/create`, `/offers/{id}/edit` → 200.
  - `Ofertas` card renders correctly inside the Tailwind ADMIN section.
  - `POST /offers` creates the offer + product rows in the DB.
- ✅ Customer flow:
  - `GET /order/offers` → 200, lists active offers with `Añadir` buttons.
  - `GET /order/addoffer/{id}` → 302 to `/basket`.
  - Basket consolidates the bundle's lines (1× Hamburguesa €8.80, 2× Coca Cola €3.30, Ajuste oferta €0.40) and totals exactly **€12.50**, matching the configured offer price.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8d5558af-67ad-4c7e-93da-f62ec381cc44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8d5558af-67ad-4c7e-93da-f62ec381cc44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

